### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: erlang
+otp_release:
+  - 17.0
+env:
+  - ELIXIR="v0.14.1"
+  - ELIXIR="v0.14.2"
+  - ELIXIR="v0.14.3"
+install: mix deps.get
+before_install:
+  - mkdir -p vendor/elixir
+  - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
+  - export PATH="$PATH:$PWD/vendor/elixir/bin"
+  - export MIX_ENV=test
+  - mix local.hex --force
+script: mix test
+services:
+  - rabbitmq


### PR DESCRIPTION
I don't know if this is something wanted, but here's my PR to add Travis CI yaml file.

It will run using Elixir 0.14.1, 0.14.2 and 0.14.3: https://travis-ci.org/edgurgel/amqp/builds/30956261

You just need to enable the webhook: http://docs.travis-ci.com/user/getting-started/#Step-two%3A-Activate-GitHub-Webhook
