### PR TITLE
Add test to Connection when connecting to unknown host

### DIFF
--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -23,4 +23,7 @@ defmodule ConnectionTest do
     assert :ok = Connection.close(conn)
   end
 
+  test "open connection on unknown host" do
+    assert {:error, :unknown_host} = Connection.open "amqp://unknown_host"
+  end
 end


### PR DESCRIPTION
Add a simple test to `Connection.open` on unknown host.
