### PR TITLE
Add docs badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ before_script:
   - mix local.hex --force
   - mix deps.get
 script: mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/pma/amqp.png?branch=master)](https://travis-ci.org/pma/amqp)
 [![Hex Version](http://img.shields.io/hexpm/v/amqp.svg)](https://hex.pm/packages/amqp)
+[![Inline docs](http://inch-ci.org/github/pma/amqp.svg?branch=master)](http://inch-ci.org/github/pma/amqp)
 
 Simple Elixir wrapper for the Erlang RabbitMQ client.
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule AMQP.Mixfile do
 
   defp deps do
     [{:earmark, "~> 0.1", only: :docs},
-     {:ex_doc, "~> 0.5", only: :docs},
+     {:ex_doc, "~> 0.6", only: :docs},
+     {:inch_ex, "~> 0.2", only: :docs},
      {:amqp_client, "~> 3.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"amqp_client": {:package, "3.0.2"},
   "earmark": {:package, "0.1.10"},
-  "ex_doc": {:package, "0.5.2"},
+  "ex_doc": {:package, "0.6.0"},
+  "inch_ex": {:package, "0.2.0"},
+  "json": {:package, "0.3.2"},
   "rabbit_common": {:package, "3.0.2"}}


### PR DESCRIPTION
Hi there,

I saw you tried to add this project to [Inch CI](http://inch-ci.org/). As mentioned in the post over at Phoenix, I do not yet have a good workflow for Elixir projects. 

This PR would add `inch_ex` as a dependency to your project and report the docs to Inch CI via Travis (and build the badge for you).

If you have any questions or remarks, just post them here or in the [Phoenix discussion](https://github.com/phoenixframework/phoenix/pull/404). :neckbeard: 
