### PR TITLE
adding return and confirmation handlers

### DIFF
--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -305,4 +305,19 @@ defmodule AMQP.Basic do
     basic_cancel_ok(consumer_tag: consumer_tag) = :amqp_channel.call pid, basic_cancel
     {:ok, consumer_tag}
   end
+
+  @doc """
+  Registers a process as a return handler for the given channel.
+  """
+  def register_return_handler(%Channel{pid: pid}, handler_pid) do
+    :amqp_channel.register_return_handler(pid, handler_pid)
+  end
+
+  @doc """
+  Unregisters a process previously registered as a return handler
+  for the given channel.
+  """
+  def unregister_return_handler(%Channel{pid: pid}) do
+    :amqp_channel.unregister_return_handler(pid)
+  end
 end

--- a/lib/amqp/confirm.ex
+++ b/lib/amqp/confirm.ex
@@ -44,4 +44,18 @@ defmodule AMQP.Confirm do
     :amqp_channel.wait_for_confirms_or_die(pid, timeout)
   end
 
+  @doc """
+  Registers a process as a confirmation handler for the given channel.
+  """
+  def register_confirm_handler(%Channel{pid: pid}, handler_pid) do
+    :amqp_channel.register_confirm_handler(pid, handler_pid)
+  end
+
+  @doc """
+  Unregisters a process previously registered as a confirmation handler
+  for the given channel.
+  """
+  def unregister_confirm_handler(%Channel{pid: pid}) do
+    :amqp_channel.unregister_confirm_handler(pid)
+  end
 end


### PR DESCRIPTION
Hello,

I couldn't find these features in the code, so maybe I'm missing something (or maybe not). This pull adds the capability of registering a confirmation handler and a return handler, when one wants to follow up on what happened with the sent messages on a more customized way. I hope you're ok with the location for the functions.

Thanks in advance!