### PR TITLE
Add type casting

### DIFF
--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -5,6 +5,7 @@ defmodule AMQP.Basic do
 
   require Record
   import AMQP.Core
+  alias AMQP.Utils
   alias AMQP.Channel
 
   Record.defrecordp :amqp_msg, [props: p_basic(), payload: ""]
@@ -57,7 +58,7 @@ defmodule AMQP.Basic do
     p_basic =
       p_basic(content_type:     Keyword.get(options, :content_type,     :undefined),
               content_encoding: Keyword.get(options, :content_encoding, :undefined),
-              headers:          Keyword.get(options, :headers,          :undefined),
+              headers:          Keyword.get(options, :headers,          :undefined) |> Utils.to_type_tuple,
               delivery_mode:    if(options[:persistent], do: 2, else: 1),
               priority:         Keyword.get(options, :priority,         :undefined),
               correlation_id:   Keyword.get(options, :correlation_id,   :undefined),

--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -7,6 +7,7 @@ defmodule AMQP.Queue do
 
   alias AMQP.Channel
   alias AMQP.Basic
+  alias AMQP.Utils
 
   @doc """
   Declares a queue. The optional `queue` parameter is used to set the name.
@@ -46,7 +47,7 @@ defmodule AMQP.Queue do
                  exchange:    exchange,
                  routing_key: Keyword.get(options, :routing_key, ""),
                  nowait:      Keyword.get(options, :no_wait,     false),
-                 arguments:   Keyword.get(options, :arguments,   []))
+                 arguments:   Keyword.get(options, :arguments,   []) |> Utils.to_type_tuple)
     queue_bind_ok() = :amqp_channel.call pid, queue_bind
     :ok
   end

--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -31,7 +31,7 @@ defmodule AMQP.Queue do
                     exclusive:   Keyword.get(options, :exclusive,   false),
                     auto_delete: Keyword.get(options, :auto_delete, false),
                     nowait:      Keyword.get(options, :no_wait,     false),
-                    arguments:   Keyword.get(options, :arguments,   []))
+                    arguments:   Keyword.get(options, :arguments,   []) |> Utils.to_type_tuple)
     queue_declare_ok(queue:          queue,
                      message_count:  message_count,
                      consumer_count: consumer_count) = :amqp_channel.call pid, queue_declare

--- a/lib/amqp/utils.ex
+++ b/lib/amqp/utils.ex
@@ -1,0 +1,21 @@
+defmodule AMQP.Utils do
+  @moduledoc false
+
+  @doc "Converts a keyword list into a rabbit_common compatible type tuple"
+  def to_type_tuple(fields) when is_list(fields) do
+    Enum.map fields, &to_type_tuple/1
+  end
+  def to_type_tuple({name, type, value}), do: {to_string(name), type, value}
+  def to_type_tuple({name, value}) when is_boolean(value) do
+    to_type_tuple {name, :bool, value}
+  end
+  def to_type_tuple({name, value}) when is_bitstring(value) or is_atom(value) do
+    to_type_tuple {name, :longstr, value}
+  end
+  def to_type_tuple({name, value}) when is_integer(value) do
+    to_type_tuple {name, :long, value}
+  end
+  def to_type_tuple({name, value}) when is_float(value) do
+    to_type_tuple {name, :float, value}
+  end
+end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,18 @@
+defmodule UtilsTest do
+  use ExUnit.Case
+
+  alias AMQP.Utils
+
+  test "leaves correct lists as is" do
+    type_tuple = {"test", :longstr, "me"}
+
+    assert Utils.to_type_tuple(type_tuple) == type_tuple
+  end
+
+  test "converts known datatypes correctly" do
+    assert Utils.to_type_tuple([test: "me"]) == [{"test", :longstr, "me"}]
+    assert Utils.to_type_tuple([test: true]) == [{"test", :bool, true}]
+    assert Utils.to_type_tuple([test: 1]) == [{"test", :long, 1}]
+    assert Utils.to_type_tuple([test: 1.0]) == [{"test", :float, 1.0}]
+  end
+end


### PR DESCRIPTION
Fixes #5 

This is a first suggestion. It is fully backwards compatible and if they don't want to go with a "standard" type they can still use the old style.

Plus this works, too:

```Elixir
[test: "me"] + [{"some-other-field", :short, 1}]
```