### PR TITLE
handle Elixir lists/maps for AMQP headers as JSON

### DIFF
--- a/lib/amqp/utils.ex
+++ b/lib/amqp/utils.ex
@@ -19,4 +19,8 @@ defmodule AMQP.Utils do
   def to_type_tuple({name, value}) when is_float(value) do
     to_type_tuple {name, :float, value}
   end
+  def to_type_tuple({name, value}) when is_list(value) or is_map(value) do
+    json = Poison.Encoder.encode(value, []) |> to_string()
+    to_type_tuple {name, :longstr, json}
+  end
 end


### PR DESCRIPTION
Since the representation changes to string here the user would need to deserialize again afterwards... but right now it just errors if you try to put list/map values into a header value, so this seems like an improvement.