### PR TITLE
Remove xmerl, rabbit_common from applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule AMQP.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :xmerl, :amqp_client, :rabbit_common]]
+    [applications: [:logger, :amqp_client]]
   end
 
   defp deps do


### PR DESCRIPTION
Since the dependency `amqp_client` properly lists both of these in its [`applications` list][1], these are not required here. Also, we are not directly using either of these packages at runtime, so there is no reason to include them here.

[1]: https://github.com/jbrisbin/amqp_client/blob/8735962962ff45fcc96092db6e7c5af6ea4fc520/src/amqp_client.app.src#L8