### PR TITLE
Support reading a connection URL at runtime

### DIFF
--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -67,6 +67,9 @@ defmodule AMQP.Connection do
       iex> AMQP.Connection.open \"amqp://guest:guest@localhost\"
       {:ok, %AMQP.Connection{}}
 
+      iex> AMQP.Connection.open {:system, \"AMQP_URL\"}
+      {:ok, %AMQP.Connection{}}
+
   """
   def open(options \\ [])
 
@@ -96,6 +99,10 @@ defmodule AMQP.Connection do
       {:ok, amqp_params} -> do_open(amqp_params)
       error              -> error
     end
+  end
+
+  def open({:system, env}) when is_binary(env) do
+    open(System.get_env(env))
   end
 
   @doc """

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -23,4 +23,10 @@ defmodule ConnectionTest do
     assert :ok = Connection.close(conn)
   end
 
+  test "open connection using an environment variable" do
+    :ok = System.put_env("AMQP_URL", "amqp://localhost")
+    assert {:ok, conn} = Connection.open {:system, "AMQP_URL"}
+    assert :ok = Connection.close(conn)
+  end
+
 end


### PR DESCRIPTION
When deploying to certain platforms, like Heroku, it's desirable to read a connection URL at runtime instead of at compile time. This because it allows you to reuse the same compiled "slug" in different environments, with different configurations being read from environment variables.

Inspired by `ecto`'s support for this feature, see <https://github.com/elixir-lang/ecto/blob/v1.1.5/lib/ecto/repo/supervisor.ex#L61-L77>.