### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/pma/amqp.png?branch=master)](https://travis-ci.org/pma/amqp)
 [![Hex Version](http://img.shields.io/hexpm/v/amqp.svg)](https://hex.pm/packages/amqp)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/pma/amqp.svg)](https://beta.hexfaktor.org/github/pma/amqp)
 [![Inline docs](http://inch-ci.org/github/pma/amqp.svg?branch=master)](http://inch-ci.org/github/pma/amqp)
 
 Simple Elixir wrapper for the Erlang RabbitMQ client.


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/pma/amqp.svg)](https://beta.hexfaktor.org/github/pma/amqp) [![Inline docs](http://inch-ci.org/github/pma/amqp.svg?branch=master)](http://inch-ci.org/github/pma/amqp)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!
