### PR TITLE
add auth_mechanisms in  options

### DIFF
--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -86,7 +86,8 @@ defmodule AMQP.Connection do
                           connection_timeout: Keyword.get(options, :connection_timeout, :infinity),
                           ssl_options:        Keyword.get(options, :ssl_options,        :none),
                           client_properties:  Keyword.get(options, :client_properties,  []),
-                          socket_options:     Keyword.get(options, :socket_options,     []))
+                          socket_options:     Keyword.get(options, :socket_options,     []),
+                          auth_mechanisms:    Keyword.get(options, :auth_mechanisms,    [&:amqp_auth_mechanisms.plain/3, &:amqp_auth_mechanisms.amqplain/3]))
 
     do_open(amqp_params)
   end


### PR DESCRIPTION
Hi, I found that I'm unable to connect to third-party server with this client 
error:
`{:no_suitable_auth_mechanism, ['EXTERNAL']}`

And I needed to pass

`Connection.open(host: host, port: port, ssl_options: [certfile: @cert], auth_mechanisms: [&:amqp_auth_mechanisms.external/3])`

What is impossible in current version