### PR TITLE
Add channel to :basic_consume_ok message

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ defmodule Consumer do
   end
 
   # Confirmation sent by the broker after registering this process as a consumer
-  def handle_info({:basic_consume_ok, %{consumer_tag: consumer_tag}}, chan) do
-    {:noreply, chan}
+  def handle_info({:basic_consume_ok, %{consumer_tag: consumer_tag, channel: channel}}, _chan) do
+    {:noreply, channel}
   end
 
   # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
@@ -197,7 +197,7 @@ end
 ```
 
 Now, when the connection drops, or if the server is down when your application
-starts, it will try to reconnect indefinitely until it succeeds. 
+starts, it will try to reconnect indefinitely until it succeeds.
 ## Types of arguments and headers
 
 The parameter `arguments` in `Queue.declare`, `Exchange.declare`, `Basic.consume` and the parameter `headers` in `Basic.publish` are a list of tuples in the form `{name, type, value}`, where `name` is a binary containing the argument/header name, `type` is an atom describing the AMQP field type and `value` a term compatible with the AMQP field type.

--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -197,7 +197,7 @@ defmodule AMQP.Basic do
     * `{:basic_deliver, payload, meta}` - This is sent for each message consumed, where \
   `payload` contains the message content and `meta` contains all the metadata set when \
   sending with Basic.publish or additional info set by the broker;
-    * `{:basic_consume_ok, %{consumer_tag: consumer_tag}}` - Sent when the consumer \
+    * `{:basic_consume_ok, %{consumer_tag: consumer_tag, channel: channel}}` - Sent when the consumer \
   process is registered with Basic.consume. The caller receives the same information \
   as the return of Basic.consume;
     * `{:basic_cancel, %{consumer_tag: consumer_tag, no_wait: no_wait}}` - Sent by the \
@@ -233,7 +233,7 @@ defmodule AMQP.Basic do
   defp do_start_consumer(chan, consumer_pid) do
     receive do
       basic_consume_ok(consumer_tag: consumer_tag) ->
-        send consumer_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag}}
+        send consumer_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag, channel: chan}}
         do_consume(chan, consumer_pid, consumer_tag)
     end
   end
@@ -280,7 +280,7 @@ defmodule AMQP.Basic do
                                                        cluster_id: cluster_id}}
         do_consume(chan, consumer_pid, consumer_tag)
       basic_consume_ok(consumer_tag: consumer_tag) ->
-        send consumer_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag}}
+        send consumer_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag, channel: chan}}
         do_consume(chan, consumer_pid, consumer_tag)
       basic_cancel_ok(consumer_tag: consumer_tag) ->
         send consumer_pid, {:basic_cancel_ok, %{consumer_tag: consumer_tag}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"amqp_client": {:hex, :amqp_client, "3.5.6"},
-  "earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "poison": {:hex, :poison, "1.5.0"},
-  "rabbit_common": {:hex, :rabbit_common, "3.5.6"}}
+%{"amqp_client": {:hex, :amqp_client, "3.5.6", "ed7e63122f32af1d503d134e6c1b088a0627e89c6b5c77b92984c841cb0939be", [:rebar], [{:rabbit_common, "3.5.6", [hex: :rabbit_common, optional: false]}]},
+  "earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "inch_ex": {:hex, :inch_ex, "0.4.0", "27829de2227edfba8fa5c431088578685c0956128b40522957077963e563e868", [:mix], [{:poison, "~> 1.2", [hex: :poison, optional: false]}]},
+  "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},
+  "rabbit_common": {:hex, :rabbit_common, "3.5.6", "ad541be86f08cdb1c04320eb4353ad30f25555569c95cc062af28cf79b74d085", [:rebar], []}}


### PR DESCRIPTION
It's possible to specify a pid/item to `Basic.consume/4` that will act as the consumer of messages. However that consumer process will have no knowledge of the channel to ack or nack messages on. If we include it in the basic_consume_ok, the consumer can use that (add it to its state or whatever). Otherwise the consumer either has to ask some other process about the channel, or couple it to whatever sets up the channel.

I'm not sure if my assumptions are correct here, but the functionality in this PR would be handy if they are I think.

Note that this is totally untested as is, and I'm sending the PR more to start the discussion around the functionality. If it's something that is wanted I'd love to add some tests.
