### PR TITLE
Ability to setup connection parameters via config.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ def application do
 end
 ```
 
+You can also set connection parameters in `config.exs` of your application:
+
+```elixir
+config :amqp,
+  host:     "localhost",
+	username: "guest",
+	password: "guest"
+```
+
 After you are done, run `mix deps.get` in your shell to fetch and compile AMQP. Start an interactive Elixir shell with `iex -S mix`.
 
 ```iex

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ You can also set connection parameters in `config.exs` of your application:
 
 ```elixir
 config :amqp,
-  host:     "localhost",
-	username: "guest",
-	password: "guest"
+  host: "localhost",
+  username: "guest",
+  password: "guest"
 ```
 
 After you are done, run `mix deps.get` in your shell to fetch and compile AMQP. Start an interactive Elixir shell with `iex -S mix`.


### PR DESCRIPTION
As described at #37 
To follow elixir-way of app configuration, adding ability to configure app via config.exs.
It should not break current behaviour, but will provide additional way to configure amqp.

Any concerns?
