### PR TITLE
Update amqp_client and support OTP 19.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: elixir
 elixir:
-  - 1.0.5
-  - 1.1.1
+  - 1.3.4
+  - 1.4.1
 sudo: false # to use faster container based build environment
 otp_release:
-  - 17.5
-  - 18.1
+  - 19.2
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.2.0-pre.1 (2017-02-08)
+
+#### Enhancements
+
+- Update amqp\_client to 3.6.7-pre.1. That means we now officially support OTP 19
+- Added changelog
+
+#### Deprecations
+
+- OTP 17 and 18 are not supported by 0.2.x anymore . Please use 0.1.x for old versions of OTP.
+

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ Simple Elixir wrapper for the Erlang RabbitMQ client.
 
 The API is based on Langohr, a Clojure client for RabbitMQ.
 
-Disclaimer: This wrapper library is built on top of a modified version of the Erlang RabbitMQ client, since currently the officially supported Erlang client is not rebar-friendly and is not available on Hex package manager.
-
 ## Usage
 
 Add AMQP as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:amqp, "0.1.4"}]
+  [{:amqp, "0.2.0-pre.1"}]
 end
 ```
 
@@ -224,16 +222,7 @@ Valid argument names in `Exchange.declare` include:
 
 * "alternate-exchange"
 
+## OTP 17 and 18
 
-## Upgrading from 0.0.6 to 0.1.0
-
-Version 0.1.0 includes the following breaking changes:
-
-  * Basic.consume now takes the consumer process pid as the third argument. This is optional
-  and defaults to the caller.
-  * When registering a consumer process with Basic.consume, this process will receive the
-  messages consumed from the Queue as the tuple `{:basic_deliver, payload, meta}` instead of
-  the previous format `{payload, meta}`.
-  * A consumer process registered with Basic.consume will have to handle (or ignore) the
-  following additional messages: `{:basic_consume_ok, %{consumer_tag: consumer_tag}}`, `{:basic_cancel, %{consumer_tag: consumer_tag}}`
-  and `{:basic_cancel_ok, %{consumer_tag: consumer_tag}}`.
+OTP 17 and 18 are supported only on [version 0.1.x](https://github.com/pma/amqp/tree/v0.1).
+Please understand that we won't make further changes to 0.1 except for major security issues.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AMQP.Mixfile do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.2.0-pre.1"
 
   def project do
     [app: :amqp,

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule AMQP.Mixfile do
     [{:earmark, "~> 1.0", only: :docs},
      {:ex_doc, "~> 0.14", only: :docs},
      {:inch_ex, "~> 0.5", only: :docs},
-     {:amqp_client, "3.5.6"}]
+     {:amqp_client, "~> 3.6.7-pre.1"}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"amqp_client": {:hex, :amqp_client, "3.5.6", "ed7e63122f32af1d503d134e6c1b088a0627e89c6b5c77b92984c841cb0939be", [:rebar], [{:rabbit_common, "3.5.6", [hex: :rabbit_common, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.0", "d659ef4168c3f626bac9687b01e8c482e61444a272628a1184bff20357d4d087", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.4", "a2b032ad141a335a0a119f49b157b36326f5928d16a1d129b0f582398fdc25d2", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "rabbit_common": {:hex, :rabbit_common, "3.5.6", "ad541be86f08cdb1c04320eb4353ad30f25555569c95cc062af28cf79b74d085", [:rebar], []}}
+%{"amqp_client": {:hex, :amqp_client, "3.6.7-pre.1", "5d689656443cf652a0114806e7e2f5c63ceac4d768382ffa08570a246f0e8eaf", [:make, :rebar3], [{:rabbit_common, "3.6.7-pre.1", [hex: :rabbit_common, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "rabbit_common": {:hex, :rabbit_common, "3.6.7-pre.1", "cd8503e4176b5187e168c73d4f703aaf50de4e2b49e8a71df78370a8b6cf7d5b", [:make], []}}


### PR DESCRIPTION
Update amqp_client to support OTP 19. Note amqp_client still has `-pre.x` suffix. We follow it and release it as `0.2.0-pre.1` for now. As soon as amqp_client releases the official version, we will update amqp too.

We drop supporting OTP 17 and 18 from `0.2` and you should use `0.1` if you are on the old platform.