### PR TITLE
add type definitions for Channel and Connection

### DIFF
--- a/lib/amqp/channel.ex
+++ b/lib/amqp/channel.ex
@@ -7,6 +7,7 @@ defmodule AMQP.Channel do
   alias AMQP.Channel
 
   defstruct [:conn, :pid]
+  @type t :: %AMQP.Channel{conn: AMQP.Connection.t, pid: pid}
 
   @doc """
   Opens a new Channel in a previously opened Connection.

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -8,6 +8,7 @@ defmodule AMQP.Connection do
   alias AMQP.Connection
 
   defstruct [:pid]
+  @type t :: %AMQP.Connection{pid: pid}
 
   @doc """
   Opens an new Connection to an AMQP broker.


### PR DESCRIPTION
adding type definitions for these structs is very useful, not only when using function type annotations, but also (especially) when writing new behaviours that require functions that make use of these types. the `Module.t` naming convention is the same style as the standard library.