### PR TITLE
Add rabbit_common to deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,10 +21,14 @@ defmodule AMQP.Mixfile do
   end
 
   defp deps do
-    [{:earmark, "~> 1.0", only: :docs},
-     {:ex_doc, "~> 0.14", only: :docs},
-     {:inch_ex, "~> 0.5", only: :docs},
-     {:amqp_client, "~> 3.6.7-pre.1"}]
+    [
+      {:amqp_client, "~> 3.6.7-pre.1"},
+      {:rabbit_common, "~> 3.6.7-pre.1"},
+
+      {:earmark, "~> 1.0", only: :docs},
+      {:ex_doc, "~> 0.14", only: :docs},
+      {:inch_ex, "~> 0.5", only: :docs}
+    ]
   end
 
   defp description do


### PR DESCRIPTION
Although the library should be picked up as a dependency of amqp_client, it is not happening at first run of mix deps.get. Fix the issue by explicitly specifying the library.

See https://github.com/pma/amqp/issues/54#issuecomment-281340679