### PR TITLE
Support direct connections to RabbitMQ

### DIFF
--- a/lib/amqp/core.ex
+++ b/lib/amqp/core.ex
@@ -41,4 +41,6 @@ defmodule AMQP.Core do
   Record.defrecord :queue_declare,       :'queue.declare',       Record.extract(:'queue.declare',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :exchange_bind,       :'exchange.bind',       Record.extract(:'exchange.bind',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :amqp_params_network, :'amqp_params_network', Record.extract(:'amqp_params_network', from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_params_direct,  :'amqp_params_direct',  Record.extract(:'amqp_params_direct',  from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_adapter_info,   :'amqp_adapter_info',   Record.extract(:'amqp_adapter_info',   from_lib: "amqp_client/include/amqp_client.hrl")
 end

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -3,6 +3,23 @@ defmodule ConnectionTest do
 
   alias AMQP.Connection
 
+  test "open direct connection" do
+    # This test assumes that we have a running RabbitMQ with short
+    # nodename 'rabbit@localhost', and that it uses the same Erlang
+    # cookie as we do. And it's better to have RabbitMQ of version
+    # equal to that of amqp_client library used. We can achieve this
+    # with following sequence of commands under the same user that
+    # will run the test-suite:
+    #
+    # wget https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_9/rabbitmq-server-generic-unix-3.6.9.tar.xz
+    # tar xJvf rabbitmq-server-generic-unix-3.6.9.tar.xz
+    # cd rabbitmq_server-3.6.9
+    # RABBITMQ_NODENAME=rabbit@localhost ./sbin/rabbitmq-server
+    :ok = ensure_distribution()
+    assert {:ok, conn} = Connection.open_direct node: :rabbit@localhost
+    assert :ok = Connection.close(conn)
+  end
+
   test "open connection with default settings" do
     assert {:ok, conn} = Connection.open
     assert :ok = Connection.close(conn)
@@ -21,6 +38,36 @@ defmodule ConnectionTest do
   test "open connection using uri" do
     assert {:ok, conn} = Connection.open "amqp://localhost"
     assert :ok = Connection.close(conn)
+  end
+
+  defp ensure_distribution() do
+    # Attempt to start distribution with a name randomly selected from
+    # a small pool of names (to prevent atom table exhausting in
+    # servers we'll connect to). Several attemps are made in case we
+    # are running some tests in parallel. This is taken almost
+    # directly from rabbit_cli.erl (skipping a bizzare FQDN magic).
+    case node() do
+      :nonode@nohost -> start_distribution_anon(10, :undefined)
+      _ -> :ok
+    end
+  end
+
+  defp start_distribution_anon(0, last_error) do
+    {:error, last_error}
+  end
+  defp start_distribution_anon(tries_left, _) do
+    name_candidate = generate_node_name()
+    case :net_kernel.start([name_candidate, :shortnames]) do
+      {:ok, _} -> :ok
+      {:error, reason} ->
+        start_distribution_anon(tries_left - 1, reason)
+    end
+  end
+
+  defp generate_node_name() do
+    :io_lib.format("amqp-mix-test-~2..0b", [:rand.uniform(100)])
+    |> :lists.flatten
+    |> :erlang.list_to_atom
   end
 
 end


### PR DESCRIPTION
Fixes #60 

This opens path to using this library for writing RabbitMQ plugins.
Or as a performance improvements, escpecially when RabbitMQ is being
run in embedded mode.

Sadly there is no way to provide a reliable tests for this feature, as
we need to know both the Erlang node-name of the broker and the Erlang
cookie. And e.g. for Travis with disabled `sudo` it's not possible.