### PR TITLE
Add Basic.return/2 and Basic.cancel_return/1

### DIFF
--- a/lib/amqp/core.ex
+++ b/lib/amqp/core.ex
@@ -43,4 +43,5 @@ defmodule AMQP.Core do
   Record.defrecord :amqp_params_network, :'amqp_params_network', Record.extract(:'amqp_params_network', from_lib: "amqp_client/include/amqp_client.hrl")
   Record.defrecord :amqp_params_direct,  :'amqp_params_direct',  Record.extract(:'amqp_params_direct',  from_lib: "amqp_client/include/amqp_client.hrl")
   Record.defrecord :amqp_adapter_info,   :'amqp_adapter_info',   Record.extract(:'amqp_adapter_info',   from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_msg,            :'amqp_msg',            Record.extract(:'amqp_msg',            from_lib: "amqp_client/include/amqp_client.hrl")
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], []}}
+%{"amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -15,4 +15,26 @@ defmodule BasicTest do
   test "basic publish to default exchange", meta do
     assert :ok = Basic.publish(meta[:chan], "", "", "ping")
   end
+
+  test "basic return", meta do
+    :ok = Basic.return(meta[:chan], self())
+
+    exchange = ""
+    routing_key = "non-existent-queue"
+    payload = "payload"
+
+    Basic.publish(meta[:chan], exchange, routing_key, payload, mandatory: true)
+
+    assert_receive {:basic_return,
+                     ^payload,
+                     %{routing_key: ^routing_key,
+                       exchange: ^exchange,
+                       reply_text: "NO_ROUTE"}}
+
+    :ok = Basic.cancel_return(meta[:chan])
+
+    Basic.publish(meta[:chan], exchange, routing_key, payload, mandatory: true)
+
+    refute_receive {:basic_return, _payload, _properties}
+  end
 end


### PR DESCRIPTION
This adds `:amqp_channel.register_return_handler/2` and
`:amqp_channel.unregister_return_handler/1` mirror functions
to `AMQP.Basic` module under names `Basic.return/2` and
`Basic.cancel_return/1` respectively. Similar mechanism as
in `AMQP.Basic.consume/4` is used to transform Erlang records to tuples.