### PR TITLE
OTP 20 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ otp_release:
   - 19.3
 matrix:
   include:
+    - elixir: 1.4.4
+      otp_release: 19.3
     - elixir: 1.4.5
       otp_release: 20.0
 script: mix test --exclude skip_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: elixir
-elixir:
-  - 1.3.4
-  - 1.4.1
 sudo: false # to use faster container based build environment
+elixir:
+  - 1.4.4
 otp_release:
-  - 19.2
+  - 19.3
+matrix:
+  include:
+    - elixir: 1.4.5
+      otp_release: 20.0
 script: mix test --exclude skip_ci
 after_script:
   - mix deps.get --only docs

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+%{"amqp_client": {:hex, :amqp_client, "3.6.10", "f26fbacca4e71f58eba1a57746e5f10598550aa46e89bc67060da6ad1a6d95d5", [:make, :rebar3], [{:rabbit_common, "3.6.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}
+  "rabbit_common": {:hex, :rabbit_common, "3.6.10", "2217845381350258c5714c22905ec197af0c4dd38eb3b6a5ddbf55c5bd93f127", [:make, :rebar3], [], "hexpm"}}

--- a/test/exchange_test.exs
+++ b/test/exchange_test.exs
@@ -72,6 +72,6 @@ defmodule ExchangeTest do
   end
 
   defp rand_name do
-    :crypto.rand_bytes(8) |> Base.encode64
+    :crypto.strong_rand_bytes(8) |> Base.encode64
   end
 end

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -64,6 +64,6 @@ defmodule QueueTest do
   end
 
   defp rand_name do
-    :crypto.rand_bytes(8) |> Base.encode64
+    :crypto.strong_rand_bytes(8) |> Base.encode64
   end
 end


### PR DESCRIPTION
It seems AMQP works with OTP 20 and Elixir 1.4.5 as it is. Fix some test helper and change travis config to run with the latest version.

**However we highly recommend you to wait for [amqp-client](https://github.com/rabbitmq/rabbitmq-erlang-client) to release `3.6.11` before updating OTP release for your application**

Read [their release note](https://github.com/rabbitmq/rabbitmq-server/releases) for more details.