### PR TITLE
Correctly handle closing/blocking response from amqp_channel:call/2

### DIFF
--- a/lib/amqp/confirm.ex
+++ b/lib/amqp/confirm.ex
@@ -10,10 +10,12 @@ defmodule AMQP.Confirm do
   @doc """
   Activates publishing confirmations on the channel.
   """
-  @spec select(Channel.t) :: :ok
+  @spec select(Channel.t) :: :ok | AMQP.Basic.error
   def select(%Channel{pid: pid}) do
-    confirm_select_ok() = :amqp_channel.call pid, confirm_select()
-    :ok
+    case :amqp_channel.call(pid, confirm_select()) do
+      confirm_select_ok() -> :ok
+      error -> {:error, error}
+    end
   end
 
   @doc """

--- a/lib/amqp/core.ex
+++ b/lib/amqp/core.ex
@@ -26,6 +26,7 @@ defmodule AMQP.Core do
   Record.defrecord :basic_deliver,       :'basic.deliver',       Record.extract(:'basic.deliver',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :basic_reject,        :'basic.reject',        Record.extract(:'basic.reject',        from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :basic_recover,       :'basic.recover',       Record.extract(:'basic.recover',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
+  Record.defrecord :basic_recover_ok,    :'basic.recover_ok',    Record.extract(:'basic.recover_ok',    from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :exchange_declare_ok, :'exchange.declare_ok', Record.extract(:'exchange.declare_ok', from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :exchange_delete,     :'exchange.delete',     Record.extract(:'exchange.delete',     from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :exchange_delete_ok,  :'exchange.delete_ok',  Record.extract(:'exchange.delete_ok',  from_lib: "rabbit_common/include/rabbit_framing.hrl")

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule AMQP.Mixfile do
      dialyzer: [
        ignore_warnings: "dialyzer.ignore-warnings",
        plt_add_deps: :transitive,
-       flags: [:error_handling, :race_conditions, :no_opaque]
+       flags: [:error_handling, :race_conditions, :no_opaque, :underspecs]
      ],
      docs: [extras: ["README.md"], main: "readme",
             source_ref: "v#{@version}",


### PR DESCRIPTION
There might be situations when application sends messages to closing or blocked channel.
In this case `amqp_channel:call/2` will return `:closing` or `:blocked` atom instead
of normal response. This commits adds support for such responses to all functions that
communicate with AMQP channel.