### PR TITLE
Fix publish typespec

### DIFF
--- a/lib/amqp/channel.ex
+++ b/lib/amqp/channel.ex
@@ -6,7 +6,7 @@ defmodule AMQP.Channel do
   alias AMQP.{Connection, Channel}
 
   defstruct [:conn, :pid]
-  @type t :: %Channel{conn: Connection.t, pid: pid}
+  @type t :: %Channel{conn: Connection.t | nil, pid: pid}
 
   @doc """
   Opens a new Channel in a previously opened Connection.


### PR DESCRIPTION
This PR updates the typespec of the `Channel.t` param to `%Channel{pid: pid}` since the channel's `:conn` property isn't used in the body of the function. This was causing an error in a project that I'm working on where we are holding onto the pid of the channel as a named pid and don't need to reconstruct `%AMQP.Connection` each time `publish` is called. This issue surfaced when upgrading to the newest `amqp` version, which now has typespecs.