### PR TITLE
Dependency updates

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,10 +33,10 @@ defmodule AMQP.Mixfile do
       # We have an issue on rebar3 dependencies.
       # https://github.com/pma/amqp/issues/78
       {:goldrush, "~> 0.1.0"},
-      {:jsx, ">= 2.8.0 and < 3.0.0"},
+      {:jsx, "~> 2.8 or ~> 2.9"},
       {:lager, "~> 3.5"},
-      {:ranch, "~> 1.5"},
-      {:ranch_proxy_protocol, "~> 1.5"},
+      {:ranch, "~> 1.4 or ~> 1.5"},
+      {:ranch_proxy_protocol, "~> 1.4 or ~> 1.5"},
       {:recon, "~> 2.3.2"},
 
       {:earmark, "~> 1.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -27,8 +27,8 @@ defmodule AMQP.Mixfile do
 
   defp deps do
     [
-      {:amqp_client, "~> 3.7.5"},
-      {:rabbit_common, "~> 3.7.5"},
+      {:amqp_client, "~> 3.7"},
+      {:rabbit_common, "~> 3.7"},
 
       # We have an issue on rebar3 dependencies.
       # https://github.com/pma/amqp/issues/78

--- a/mix.exs
+++ b/mix.exs
@@ -27,16 +27,16 @@ defmodule AMQP.Mixfile do
 
   defp deps do
     [
-      {:amqp_client, "~> 3.7.3"},
-      {:rabbit_common, "~> 3.7.3"},
+      {:amqp_client, "~> 3.7.5"},
+      {:rabbit_common, "~> 3.7.5"},
 
       # We have an issue on rebar3 dependencies.
       # https://github.com/pma/amqp/issues/78
       {:goldrush, "~> 0.1.0"},
-      {:jsx, "~> 2.8"},
+      {:jsx, ">= 2.8.0 and < 3.0.0"},
       {:lager, "~> 3.5"},
-      {:ranch, "~> 1.4"},
-      {:ranch_proxy_protocol, "~> 1.4"},
+      {:ranch, "~> 1.5"},
+      {:ranch_proxy_protocol, "~> 1.5"},
       {:recon, "~> 2.3.2"},
 
       {:earmark, "~> 1.0", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "amqp_client": {:hex, :amqp_client, "3.7.3", "29a818d3871de5f8484e876ad34b0a940b2cecd6c6dfbed30d9b1679072eb9bc", [:make, :rebar3], [{:rabbit_common, "3.7.3", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "amqp_client": {:hex, :amqp_client, "3.7.5", "ee5ff6209ca4be0ff950e92775f4e4aab272c74003abd84ded9cff64af1b597a", [], [{:rabbit_common, "3.7.5", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
@@ -8,8 +8,8 @@
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [], [], "hexpm"},
   "lager": {:hex, :lager, "3.5.1", "63897a61af646c59bb928fee9756ce8bdd02d5a1a2f3551d4a5e38386c2cc071", [], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "rabbit_common": {:hex, :rabbit_common, "3.7.3", "f23ed393e12150e3d3b6ef640be7bfddfefce72a65e2ce27d44249ef84287c96", [:make, :rebar3], [{:jsx, "2.8.2", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.5.1", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}, {:ranch_proxy_protocol, "1.4.4", [hex: :ranch_proxy_protocol, repo: "hexpm", optional: false]}, {:recon, "2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
-  "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [], [], "hexpm"},
-  "ranch_proxy_protocol": {:hex, :ranch_proxy_protocol, "1.4.4", "8853b11757a9798e86c7d6d0ff783a8e2e87f77052aad7f1c91108f254ba4a9c", [], [{:ranch, "1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "rabbit_common": {:hex, :rabbit_common, "3.7.5", "3346c2c65df2528891c3113aa33e78aadbd5e6996e4230b937c2429f86861268", [], [{:jsx, "2.8.2", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.5.1", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}, {:ranch_proxy_protocol, "1.5.0", [hex: :ranch_proxy_protocol, repo: "hexpm", optional: false]}, {:recon, "2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [], [], "hexpm"},
+  "ranch_proxy_protocol": {:hex, :ranch_proxy_protocol, "1.5.0", "e698aaeb590ad504b649dc0d3055abee6caf0b49d3caee1a080ae83b5b499f30", [], [{:ranch, "1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This updates dependency version requirements to cover all RabbitMQ 3.7.x releases. Besides better compatibility with RabbitMQ Erlang client and `rabbit_common` versions, this would allow team RabbitMQ use `1.0.x` versions of this library in rabbitmq-cli tests. Currently we are stuck at `0.2.x`.