### PR TITLE
Remove bad usage of spawn in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ defmodule Consumer do
   end
 
   def handle_info({:basic_deliver, payload, %{delivery_tag: tag, redelivered: redelivered}}, chan) do
-    spawn fn -> consume(chan, tag, redelivered, payload) end
+    # You might want to run payload consumption in separate Tasks in production
+    consume(chan, tag, redelivered, payload)
     {:noreply, chan}
   end
 


### PR DESCRIPTION
I believe using unlinked raw processes in the readme gives a bad example for novices looking at this, and might copy the whole example verbatim.