### PR TITLE
unquote quoted atoms to silence Elixir 1.7 warnings

### DIFF
--- a/lib/amqp/core.ex
+++ b/lib/amqp/core.ex
@@ -41,8 +41,8 @@ defmodule AMQP.Core do
   Record.defrecord :exchange_declare,    :'exchange.declare',    Record.extract(:'exchange.declare',    from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :queue_declare,       :'queue.declare',       Record.extract(:'queue.declare',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
   Record.defrecord :exchange_bind,       :'exchange.bind',       Record.extract(:'exchange.bind',       from_lib: "rabbit_common/include/rabbit_framing.hrl")
-  Record.defrecord :amqp_params_network, :'amqp_params_network', Record.extract(:'amqp_params_network', from_lib: "amqp_client/include/amqp_client.hrl")
-  Record.defrecord :amqp_params_direct,  :'amqp_params_direct',  Record.extract(:'amqp_params_direct',  from_lib: "amqp_client/include/amqp_client.hrl")
-  Record.defrecord :amqp_adapter_info,   :'amqp_adapter_info',   Record.extract(:'amqp_adapter_info',   from_lib: "amqp_client/include/amqp_client.hrl")
-  Record.defrecord :amqp_msg,            :'amqp_msg',            Record.extract(:'amqp_msg',            from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_params_network, :amqp_params_network,   Record.extract(:amqp_params_network,   from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_params_direct,  :amqp_params_direct,    Record.extract(:amqp_params_direct,    from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_adapter_info,   :amqp_adapter_info,     Record.extract(:amqp_adapter_info,     from_lib: "amqp_client/include/amqp_client.hrl")
+  Record.defrecord :amqp_msg,            :amqp_msg,              Record.extract(:amqp_msg,              from_lib: "amqp_client/include/amqp_client.hrl")
 end


### PR DESCRIPTION
Elixir 1.7 produces these warnings when compileing:

```
==> amqp
Compiling 10 files (.ex)
warning: found quoted atom "amqp_params_network" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:44

warning: found quoted atom "amqp_params_network" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:44

warning: found quoted atom "amqp_params_direct" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:45

warning: found quoted atom "amqp_params_direct" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:45

warning: found quoted atom "amqp_adapter_info" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:46

warning: found quoted atom "amqp_adapter_info" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:46

warning: found quoted atom "amqp_msg" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:47

warning: found quoted atom "amqp_msg" but the quotes are not required. Quotes should only be used to introduce atoms with foreign characters in them
  lib/amqp/core.ex:47
```

Thought I'd clean it up :)