### PR TITLE
Add handling error when subscribing to queue

### DIFF
--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -268,6 +268,8 @@ defmodule AMQP.Basic do
       basic_consume_ok(consumer_tag: consumer_tag) ->
         send consumer_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag}}
         do_consume(chan, consumer_pid, consumer_tag)
+      error ->
+        send consumer_pid, error
     end
   end
 


### PR DESCRIPTION
In my project, I found the following problem.

The [adapter_pid](https://github.com/pma/amqp/compare/master...DmitryKK:master#diff-256b94bd15eb120a257c157cb076c6f9R253) process terminates only if the queue's subscribing is successful. If an error occurs during the subscription, for example, if we subscribe to a queue that does not exist, the process will live until the parent process terminates. And if the parent process tries to loop subscribing to the queue in case of an error, then gradually the number of process will reach the maximum possible value in BEAM and the application will collapse.

My solution is simple. Please as soon as possible merges to the master, or offers another solution. Thanks.