### PR TITLE
Change instructions to get latest stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you use amqp 0.X and plan to migrate to 1.0 please read our [migration guide]
 ## Usage
 
 Add AMQP as a dependency in your `mix.exs` file.
-(If you want to use the stable version, set `~> 0.2.3` to the version instead)
+(If you want to use the stable version, set `~> 0.2` to the version instead)
 
 ```elixir
 def deps do


### PR DESCRIPTION
I still need stable version, because requirements for `1.0` are incompatible with Phoenix.