### PR TITLE
Bump version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add AMQP as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:amqp, "~> 1.0"}]
+  [{:amqp, "~> 1.1"}]
 end
 ```
 


### PR DESCRIPTION
I had some ranch trouble when upgrading even though [this issue](https://github.com/pma/amqp/issues/99) had already been closed. After working on it for a bit found that I just needed to be using 1.1. Figured this could help others setting up AMQP.