### PR TITLE
Introduce channel message receiver

### DIFF
--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -1,0 +1,18 @@
+defmodule AMQP.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      worker(AMQP.Channel.ReceiverManager, [])
+    ]
+
+    opts = [strategy: :one_for_one, name: AMQP.Application]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -299,6 +299,8 @@ defmodule AMQP.Basic do
   """
   @spec cancel_return(Channel.t) :: :ok
   def cancel_return(%Channel{pid: pid}) do
+    # Currently we don't remove the receiver.
+    # The receiver will be deleted automatically when channel is closed.
     :amqp_channel.unregister_return_handler(pid)
   end
 end

--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -2,39 +2,186 @@ defmodule AMQP.Channel.Receiver do
   @moduledoc false
 
   import AMQP.Core
+  alias AMQP.{Basic, Channel, Confirm}
   alias AMQP.Channel.ReceiverManager
 
   @doc """
   Handles channel messages.
   """
-  @spec handle_message(pid(), pid()) :: no_return
-  def handle_message(chan_pid, client_pid) do
+  @spec handle_message(pid(), pid(), map()) :: no_return
+  def handle_message(chan_pid, client_pid, handlers) do
     receive do
       {:DOWN, _ref, :process, _pid, reason} ->
         ReceiverManager.unregister_receiver(chan_pid, client_pid)
+        handle_message(chan_pid, client_pid, handlers)
         exit(reason)
 
       {:EXIT, _ref, reason} ->
         ReceiverManager.unregister_receiver(chan_pid, client_pid)
         exit(reason)
 
+      {:add_handler, handler, opts} ->
+        new_handlers = add_handler(handlers, handler, opts)
+        handle_message(chan_pid, client_pid, new_handlers)
+
       msg ->
-        do_handle_message(client_pid, msg)
-        handle_message(chan_pid, client_pid)
+        with true <- Process.alive?(client_pid),
+             new_handlers <- do_handle_message(client_pid, handlers, msg),
+             size when size > 0 <- map_size(new_handlers) do
+          handle_message(chan_pid, client_pid, new_handlers)
+        else
+          _ -> ReceiverManager.unregister_receiver(chan_pid, client_pid)
+        end
     end
   end
 
-  # -- :amqp_channel.register_confirm_handler
+  defp add_handler(handlers, :consume, opts) do
+    if opts[:tag] do
+      consumer_tags = (handlers[:consume] || []) ++ [opts[:tag]]
+      Map.put(handlers, :consume, consumer_tags |> Enum.uniq())
+    else
+      handlers
+    end
+  end
 
-  defp do_handle_message(client_pid,
+  defp add_handler(handlers, handler, _) do
+    Map.put(handlers, handler, true)
+  end
+
+  defp remove_handler(handlers, :consume, opts) do
+    if handlers[:consume] && opts[:tag] do
+      consumer_tags = List.delete(handlers[:consume], opts[:tag])
+      if length(consumer_tags) == 0 do
+        Map.delete(handlers, :consume)
+      else
+        Map.put(handlers, :consume, consumer_tags)
+      end
+    else
+      handlers
+    end
+  end
+
+  defp remove_handler(handlers, handler, _) do
+    Map.delete(handlers, handler)
+  end
+
+  defp cancel_handlers(chan_pid, handlers) do
+    handlers
+    |> Enum.each(fn {handler, value} -> cancel_handler(chan_pid, handler, value) end)
+  end
+
+  defp cancel_handler(chan_pid, :confirm, true) do
+    Confirm.unregister_handler(%Channel{pid: chan_pid})
+  end
+
+  defp cancel_handler(chan_pid, :return, true) do
+    Basic.cancel_return(%Channel{pid: chan_pid})
+  end
+
+  defp cancel_handler(chan_pid, :consume, tags) do
+    chan = %Channel{pid: chan_pid}
+    tags
+    |> Enum.each(fn consumer_tag ->
+      Basic.cancel(chan, consumer_tag)
+    end)
+  end
+
+  # -- Confirm.register_handler
+
+  defp do_handle_message(client_pid, handlers,
     basic_ack(delivery_tag: delivery_tag, multiple: multiple))
   do
     send(client_pid, {:basic_ack, delivery_tag, multiple})
+    handlers
   end
 
-  defp do_handle_message(client_pid,
+  defp do_handle_message(client_pid, handlers,
     basic_nack(delivery_tag: delivery_tag, multiple: multiple))
   do
     send(client_pid, {:basic_nack, delivery_tag, multiple})
+    handlers
+  end
+
+  # -- Basic.consume
+
+  defp do_handle_message(client_pid, handlers,
+    basic_consume_ok(consumer_tag: consumer_tag))
+  do
+    send(client_pid, {:basic_consume_ok, %{consumer_tag: consumer_tag}})
+    add_handler(handlers, :consume, tag: consumer_tag)
+  end
+
+  defp do_handle_message(client_pid, handlers,
+    basic_cancel_ok(consumer_tag: consumer_tag))
+  do
+    send(client_pid, {:basic_cancel_ok, %{consumer_tag: consumer_tag}})
+    remove_handler(handlers, :consume, tag: consumer_tag)
+  end
+
+  defp do_handle_message(client_pid, handlers,
+    basic_cancel(consumer_tag: consumer_tag, nowait: no_wait))
+  do
+    send(client_pid, {:basic_cancel, %{consumer_tag: consumer_tag, no_wait: no_wait}})
+    remove_handler(handlers, :consume, tag: consumer_tag)
+  end
+
+  defp do_handle_message(client_pid, handlers, {
+    basic_deliver(
+      consumer_tag: consumer_tag,
+      delivery_tag: delivery_tag,
+      redelivered: redelivered,
+      exchange: exchange,
+      routing_key: routing_key
+    ),
+    amqp_msg(
+      props: p_basic(
+        content_type: content_type,
+        content_encoding: content_encoding,
+        headers: headers,
+        delivery_mode: delivery_mode,
+        priority: priority,
+        correlation_id: correlation_id,
+        reply_to: reply_to,
+        expiration: expiration,
+        message_id: message_id,
+        timestamp: timestamp,
+        type: type,
+        user_id: user_id,
+        app_id: app_id,
+        cluster_id: cluster_id
+      ),
+      payload: payload
+    )})
+  do
+    send(client_pid, {:basic_deliver, payload, %{
+      consumer_tag: consumer_tag,
+      delivery_tag: delivery_tag,
+      redelivered: redelivered,
+      exchange: exchange,
+      routing_key: routing_key,
+      content_type: content_type,
+      content_encoding: content_encoding,
+      headers: headers,
+      persistent: delivery_mode == 2,
+      priority: priority,
+      correlation_id: correlation_id,
+      reply_to: reply_to,
+      expiration: expiration,
+      message_id: message_id,
+      timestamp: timestamp,
+      type: type,
+      user_id: user_id,
+      app_id: app_id,
+      cluster_id: cluster_id
+    }})
+
+    handlers
+  end
+
+  # -- Unhandled message
+  defp do_handle_message(client_pid, handlers, maybe_error) do
+    send(client_pid, maybe_error)
+
+    handlers
   end
 end

--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -1,0 +1,11 @@
+defmodule AMQP.Channel.Receiver do
+  @moduledoc false
+
+  def handle_message(chan_pid, client_pid) do
+    receive do
+      msg ->
+        IO.inspect(msg)
+        handle_message(chan_pid, client_pid)
+    end
+  end
+end

--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -1,8 +1,20 @@
 defmodule AMQP.Channel.Receiver do
   @moduledoc false
 
+  alias AMQP.Channel.ReceiverManager
+
   def handle_message(chan_pid, client_pid) do
     receive do
+      {:DOWN, _ref, :process, _pid, reason} ->
+        ReceiverManager.unregister_receiver(chan_pid, client_pid)
+        IO.inspect(reason)
+        exit(reason)
+
+      {:EXIT, _ref, reason} ->
+        ReceiverManager.unregister_receiver(chan_pid, client_pid)
+        IO.inspect(reason)
+        exit(reason)
+
       msg ->
         IO.inspect(msg)
         handle_message(chan_pid, client_pid)

--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -1,23 +1,40 @@
 defmodule AMQP.Channel.Receiver do
   @moduledoc false
 
+  import AMQP.Core
   alias AMQP.Channel.ReceiverManager
 
+  @doc """
+  Handles channel messages.
+  """
+  @spec handle_message(pid(), pid()) :: no_return
   def handle_message(chan_pid, client_pid) do
     receive do
       {:DOWN, _ref, :process, _pid, reason} ->
         ReceiverManager.unregister_receiver(chan_pid, client_pid)
-        IO.inspect(reason)
         exit(reason)
 
       {:EXIT, _ref, reason} ->
         ReceiverManager.unregister_receiver(chan_pid, client_pid)
-        IO.inspect(reason)
         exit(reason)
 
       msg ->
-        IO.inspect(msg)
+        do_handle_message(client_pid, msg)
         handle_message(chan_pid, client_pid)
     end
+  end
+
+  # -- :amqp_channel.register_confirm_handler
+
+  defp do_handle_message(client_pid,
+    basic_ack(delivery_tag: delivery_tag, multiple: multiple))
+  do
+    send(client_pid, {:basic_ack, delivery_tag, multiple})
+  end
+
+  defp do_handle_message(client_pid,
+    basic_nack(delivery_tag: delivery_tag, multiple: multiple))
+  do
+    send(client_pid, {:basic_nack, delivery_tag, multiple})
   end
 end

--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -178,9 +178,47 @@ defmodule AMQP.Channel.Receiver do
     handlers
   end
 
-  # -- Unhandled message
-  defp do_handle_message(client_pid, handlers, maybe_error) do
-    send(client_pid, maybe_error)
+  defp do_handle_message(client_pid, handlers,{
+    basic_return(reply_code: reply_code,
+                 reply_text: reply_text,
+                 exchange: exchange,
+                 routing_key: routing_key),
+    amqp_msg(props: p_basic(content_type: content_type,
+                            content_encoding: content_encoding,
+                            headers: headers,
+                            delivery_mode: delivery_mode,
+                            priority: priority,
+                            correlation_id: correlation_id,
+                            reply_to: reply_to,
+                            expiration: expiration,
+                            message_id: message_id,
+                            timestamp: timestamp,
+                            type: type,
+                            user_id: user_id,
+                            app_id: app_id,
+                            cluster_id: cluster_id), payload: payload)
+    })
+  do
+    send(client_pid, {:basic_return, payload, %{
+      reply_code: reply_code,
+      reply_text: reply_text,
+      exchange: exchange,
+      routing_key: routing_key,
+      content_type: content_type,
+      content_encoding: content_encoding,
+      headers: headers,
+      persistent: delivery_mode == 2,
+      priority: priority,
+      correlation_id: correlation_id,
+      reply_to: reply_to,
+      expiration: expiration,
+      message_id: message_id,
+      timestamp: timestamp,
+      type: type,
+      user_id: user_id,
+      app_id: app_id,
+      cluster_id: cluster_id
+    }})
 
     handlers
   end

--- a/lib/amqp/channel/receiver_manager.ex
+++ b/lib/amqp/channel/receiver_manager.ex
@@ -1,0 +1,91 @@
+defmodule AMQP.Channel.ReceiverManager do
+  @moduledoc false
+  # Manages receivers.
+  #
+  # AMQP relays messages from a channel to a client and convert
+  # [Record](https://hexdocs.pm/elixir/Record.html) to the data structure which
+  # is familiar with Elixir developer (Tuple, Map).
+  # We call the processes in between a channel and a client Receiver and
+  # this module manages them.
+  #
+  # This module ensures to have a single Receiver per a channel and a client.
+  # With that way, the sequence of the messages from channel would be always
+  # preserved.
+
+  use GenServer
+  alias AMQP.Channel.Receiver
+
+  @enforce_keys [:pid, :channel, :client]
+  @type t :: %__MODULE__{
+    pid: pid(),
+    channel: pid(),
+    client: pid(),
+    count: integer()
+  }
+  defstruct [:pid, :channel, :client, {:count, 0}]
+
+  @doc false
+  @spec start_link(map) :: GenServer.on_start()
+  def start_link(opts \\ [name: __MODULE__]) do
+    GenServer.start_link(__MODULE__, %{}, opts)
+  end
+
+  @impl true
+  def init(state = %{}) do
+    {:ok, state}
+  end
+
+  @doc """
+  Returns a receiver pid for the channel and client.
+
+  When check_in option is true, it counts up the handlers and responds unregister properly.
+  """
+  @spec get_receiver(pid(), pid(), keyword()) :: pid()
+  def get_receiver(channel, client, opts \\ []) do
+    GenServer.call(__MODULE__, {:get, channel, client, opts})
+  end
+
+  @impl true
+  def handle_call({:get, channel, client, opts}, _from, receivers) do
+    receiver =
+      receivers
+      |> get_or_spawn_receiver(channel, client)
+      |> check_in(opts[:check_in])
+
+    key = get_key(channel, client)
+    {:reply, receiver, Map.put(receivers, key, receiver)}
+  end
+
+  defp get_or_spawn_receiver(receivers, channel, client) do
+    key = get_key(channel, client)
+    if (receiver = receivers[key]) && Process.alive?(receiver.pid) do
+      receiver
+    else
+      spawn_receiver(channel, client)
+    end
+  end
+
+  defp spawn_receiver(channel, client) do
+    receiver_pid = spawn fn ->
+      Process.flag(:trap_exit, true)
+      Process.monitor(channel)
+      Process.monitor(client)
+      Process.monitor(self())
+      Receiver.handle_message(channel, client)
+    end
+
+    %__MODULE__{
+      pid: receiver_pid,
+      channel: channel,
+      client: client
+    }
+  end
+
+  defp get_key(channel, client) do
+    "#{inspect channel}-#{inspect client}"
+  end
+
+  defp check_in(receiver, true),
+    do: Map.put(receiver, :count, receiver.count + 1)
+  defp check_in(receiver, _), do: receiver
+end

--- a/lib/amqp/confirm.ex
+++ b/lib/amqp/confirm.ex
@@ -72,7 +72,7 @@ defmodule AMQP.Confirm do
   """
   @spec register_handler(Channel.t, pid) :: :ok
   def register_handler(%Channel{pid: chan_pid}, handler_pid) do
-    receiver = ReceiverManager.get_receiver(chan_pid, handler_pid)
+    receiver = ReceiverManager.register_handler(chan_pid, handler_pid, :confirm)
     :amqp_channel.register_confirm_handler(chan_pid, receiver.pid)
   end
 

--- a/lib/amqp/confirm.ex
+++ b/lib/amqp/confirm.ex
@@ -83,6 +83,8 @@ defmodule AMQP.Confirm do
   """
   @spec unregister_handler(Channel.t) :: :ok
   def unregister_handler(%Channel{pid: pid}) do
+    # Currently we don't remove the receiver.
+    # The receiver will be deleted automatically when channel is closed.
     :amqp_channel.unregister_confirm_handler(pid)
   end
 end

--- a/lib/amqp/confirm.ex
+++ b/lib/amqp/confirm.ex
@@ -5,6 +5,7 @@ defmodule AMQP.Confirm do
 
   import AMQP.Core
   alias AMQP.{Basic, Channel}
+  alias AMQP.Channel.ReceiverManager
 
   @doc """
   Activates publishing confirmations on the channel.
@@ -70,14 +71,9 @@ defmodule AMQP.Confirm do
   see https://www.rabbitmq.com/confirms.html
   """
   @spec register_handler(Channel.t, pid) :: :ok
-  def register_handler(%Channel{pid: pid}, handler_pid) do
-    adapter_pid = spawn fn ->
-      Process.flag(:trap_exit, true)
-      Process.monitor(handler_pid)
-      Process.monitor(pid)
-      handle_confirm(handler_pid)
-    end
-    :amqp_channel.register_confirm_handler(pid, adapter_pid)
+  def register_handler(%Channel{pid: chan_pid}, handler_pid) do
+    receiver = ReceiverManager.get_receiver(chan_pid, handler_pid)
+    :amqp_channel.register_confirm_handler(chan_pid, receiver.pid)
   end
 
   @doc """
@@ -89,20 +85,4 @@ defmodule AMQP.Confirm do
   def unregister_handler(%Channel{pid: pid}) do
     :amqp_channel.unregister_confirm_handler(pid)
   end
-
-  defp handle_confirm(handler_pid) do
-    receive do
-      basic_ack(delivery_tag: delivery_tag, multiple: multiple) ->
-        send(handler_pid, {:basic_ack, delivery_tag, multiple})
-        handle_confirm(handler_pid)
-
-      basic_nack(delivery_tag: delivery_tag, multiple: multiple) ->
-        send(handler_pid, {:basic_nack, delivery_tag, multiple})
-        handle_confirm(handler_pid)
-
-      {:DOWN, _ref, :process, _pid, reason} ->
-        exit(reason)
-    end
-  end
 end
-

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,10 @@ defmodule AMQP.Mixfile do
   end
 
   def application do
-    [applications: [:lager, :amqp_client]]
+    [
+      applications: [:lager, :amqp_client],
+      mod: {AMQP.Application, []}
+    ]
   end
 
   defp deps do

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -98,6 +98,8 @@ defmodule BasicTest do
 
     test "removes a receiver when queue does not exist", meta do
       catch_exit(Basic.consume(meta[:chan], "non-existent-queue"))
+
+      :timer.sleep(100)
       receiver = ReceiverManager.get_receiver(meta[:chan].pid, self())
       refute receiver
     end

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -1,10 +1,8 @@
 defmodule BasicTest do
   use ExUnit.Case
 
-  alias AMQP.Connection
-  alias AMQP.Channel
-  alias AMQP.Basic
-  alias AMQP.Queue
+  alias AMQP.{Basic, Connection, Channel, Queue}
+  alias Channel.ReceiverManager
 
   setup do
     {:ok, conn} = Connection.open
@@ -98,9 +96,10 @@ defmodule BasicTest do
       spawn fn -> assert {:error, :closing} = Basic.cancel(meta[:chan], consumer_tag) end
     end
 
-    test "receives {:DOWN, _, _, _} message when queue does not exist", meta do
+    test "removes a receiver when queue does not exist", meta do
       catch_exit(Basic.consume(meta[:chan], "non-existent-queue"))
-      assert_receive {:DOWN, _, _, _, _}
+      receiver = ReceiverManager.get_receiver(meta[:chan].pid, self())
+      refute receiver
     end
   end
 end

--- a/test/confirm_test.exs
+++ b/test/confirm_test.exs
@@ -23,10 +23,11 @@ defmodule ConfirmTest do
 
   describe "register_handler" do
     test "handler receive confirm with message seqno", ctx do
+      :ok = Confirm.register_handler(ctx[:chan], self())
       seq_no = Confirm.next_publish_seqno(ctx[:chan])
       :ok = AMQP.Basic.publish(ctx[:chan], "", "", "foo")
-      :ok = Confirm.register_handler(ctx[:chan], self())
-      assert_receive {:basic_ack, seq_no, false}
+
+      assert_receive {:basic_ack, ^seq_no, false}
       :ok = Confirm.unregister_handler(ctx[:chan])
     end
   end


### PR DESCRIPTION
The current version spawns a middle process for every handler registration. This causes a race condition that the message is not coming to the client with a right sequence.

The PR introduces a GenServer which ensures only a single message receiver per channel and client process. This makes sure original sequence of all incoming messages from RabbitMQ via a channel.