### PR TITLE
Remove unused functions

### DIFF
--- a/lib/amqp/channel/receiver.ex
+++ b/lib/amqp/channel/receiver.ex
@@ -2,7 +2,6 @@ defmodule AMQP.Channel.Receiver do
   @moduledoc false
 
   import AMQP.Core
-  alias AMQP.{Basic, Channel, Confirm}
   alias AMQP.Channel.ReceiverManager
 
   @doc """
@@ -63,27 +62,6 @@ defmodule AMQP.Channel.Receiver do
 
   defp remove_handler(handlers, handler, _) do
     Map.delete(handlers, handler)
-  end
-
-  defp cancel_handlers(chan_pid, handlers) do
-    handlers
-    |> Enum.each(fn {handler, value} -> cancel_handler(chan_pid, handler, value) end)
-  end
-
-  defp cancel_handler(chan_pid, :confirm, true) do
-    Confirm.unregister_handler(%Channel{pid: chan_pid})
-  end
-
-  defp cancel_handler(chan_pid, :return, true) do
-    Basic.cancel_return(%Channel{pid: chan_pid})
-  end
-
-  defp cancel_handler(chan_pid, :consume, tags) do
-    chan = %Channel{pid: chan_pid}
-    tags
-    |> Enum.each(fn consumer_tag ->
-      Basic.cancel(chan, consumer_tag)
-    end)
   end
 
   # -- Confirm.register_handler


### PR DESCRIPTION
## Motivation

Right now the compiler is emitting warnings because of the unused functions that exists inside the file `lib/amqp/channel/receiver.ex`.

```
==> amqp
Compiling 13 files (.ex)
warning: function cancel_handler/3 is unused
  lib/amqp/channel/receiver.ex:73

warning: function cancel_handlers/2 is unused
  lib/amqp/channel/receiver.ex:68

Generated amqp app
```

## Proposed solution

- Remove the functions `cancel_handler/3` and  `cancel_handlers/2`.
- Remove the aliases that were used by the removed functions and are not needed anymore.