### PR TITLE
Add support for opening connections with options and URI

### DIFF
--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -22,4 +22,14 @@ defmodule ConnectionTest do
     assert {:ok, conn} = Connection.open "amqp://localhost"
     assert :ok = Connection.close(conn)
   end
+  
+  test "open connection using both uri and options" do
+    assert {:ok, conn} = Connection.open "amqp://nonexistent:5672", host: 'localhost'
+    assert :ok = Connection.close(conn)
+  end
+
+  test "open connection with uri, name, and options" do
+    assert {:ok, conn} = Connection.open "amqp://nonexistent:5672", "my-connection", host: 'localhost'
+    assert :ok = Connection.close(conn)
+  end
 end


### PR DESCRIPTION
This PR reworks `AMQP.Connection.open/2` a little bit by adding the following possible calls:

| Call                       | Translates to                                |
|----------------------------|----------------------------------------------|
| `open()`                   | `open([], :undefined)` (same as before)      |
| `open(uri)`                | `open(uri, :undefined)` (same as before)     |
| `open(options)`            | `open(options, :undefined)` (same as before) |
| `open(uri, name)`          | same as before                               |
| `open(options, name)`      | same as before                               |
| `open(uri, options)`       | `open(uri, :undefined, options)` (new call)  |
| `open(uri, name, options)` | new call, merges uri and options             |

Note that the PR is perfectly backwards compatible with the previous signature of `open(uri_or_opts \\ [], name \\ :undefined)` (as you can see in the table above).

The decision to have the options have precedence over the URI when they're both present is a pretty common one (see Redix for an example) and I think it's the most intuitive one.

Closes #77.