### PR TITLE
Add the AMQP.arguments/0 type

### DIFF
--- a/lib/amqp.ex
+++ b/lib/amqp.ex
@@ -1,5 +1,25 @@
 defmodule AMQP do
-  @moduledoc false
+  @moduledoc """
+  This module provides AMQP-related types.
+  """
+
+  @type argument_type() ::
+          :longstr
+          | :signedint
+          | :decimal
+          | :timestamp
+          | :table
+          | :byte
+          | :double
+          | :float
+          | :long
+          | :short
+          | :bool
+          | :binary
+          | :void
+          | :array
+
+  @type arguments() :: [{String.t(), argument_type(), term()}]
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -36,7 +36,7 @@ defmodule AMQP.Basic do
     * `:immediate` - If set, returns an error if the broker can't deliver the message to a consumer immediately (default `false`);
     * `:content_type` - MIME Content type;
     * `:content_encoding` - MIME Content encoding;
-    * `:headers` - Message headers. Can be used with headers Exchanges;
+    * `:headers` - Message headers of type `t:AMQP.arguments/0`. Can be used with headers Exchanges;
     * `:persistent` - If set, uses persistent delivery mode. Messages marked as `persistent` that are delivered to `durable` \
                       queues will be logged to disk;
     * `:correlation_id` - application correlation identifier;
@@ -293,8 +293,8 @@ defmodule AMQP.Basic do
       have exclusive access to a queue that already has consumers.
     * `:no_wait` - If set, the consume operation is asynchronous. Defaults to
       `false`.
-    * `:arguments` - A list of arguments to pass when consuming. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when consuming (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec consume(Channel.t, String.t, pid | nil, keyword) :: {:ok, String.t} | error

--- a/lib/amqp/exchange.ex
+++ b/lib/amqp/exchange.ex
@@ -27,8 +27,8 @@ defmodule AMQP.Exchange do
     * `:internal:` If set, the exchange may not be used directly by publishers, but only when bound to other exchanges. Internal exchanges are used to construct wiring that is not visible to applications.
     * `:no_wait` - If set, the declare operation is asynchronous. Defaults to
       `false`.
-    * `:arguments` - A list of arguments to pass when declaring. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when declaring (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec declare(Channel.t, Basic.exchange, type :: atom, keyword) :: :ok | Basic.error
@@ -83,8 +83,8 @@ defmodule AMQP.Exchange do
     * `:routing_key` - the routing key to use for the binding. Defaults to `""`.
     * `:no_wait` - If set, the bind operation is asynchronous. Defaults to
       `false`.
-    * `:arguments` - A list of arguments to pass when binding. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when binding (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec bind(Channel.t, destination :: String.t, source :: String.t, keyword) :: :ok | Basic.error
@@ -111,8 +111,8 @@ defmodule AMQP.Exchange do
     * `:routing_key` - the routing key to use for the binding. Defaults to `""`.
     * `:no_wait` - If set, the declare operation is asynchronous. Defaults to
       `false`.
-    * `:arguments` - A list of arguments to pass when declaring. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when declaring (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec unbind(Channel.t, destination :: String.t, source :: String.t, keyword) :: :ok | Basic.error

--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -25,8 +25,8 @@ defmodule AMQP.Queue do
       Defaults to `false`.
     * `:no_wait` - If set, the declare operation is asynchronous. Defaults to
       `false`.
-    * `:arguments` - A list of arguments to pass when declaring. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when declaring (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec declare(Channel.t, Basic.queue, keyword) :: {:ok, map} | Basic.error
@@ -58,8 +58,8 @@ defmodule AMQP.Queue do
     * `:routing_key` - The routing key used to bind the queue to the exchange.
       Defaults to `""`.
     * `:no_wait` - If `true`, the binding is not synchronous. Defaults to `false`.
-    * `:arguments` - A list of arguments to pass when binding. See the
-      README for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when binding (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec bind(Channel.t, Basic.queue, Basic.exchange, keyword) :: :ok | Basic.error
@@ -83,8 +83,8 @@ defmodule AMQP.Queue do
   ## Options
 
     * `:routing_key` - The routing queue for removing the binding. Defaults to `""`.
-    * `:arguments` - A list of arguments to pass when unbinding. See the README
-      for more information. Defaults to `[]`.
+    * `:arguments` - A list of arguments to pass when unbinding (of type `t:AMQP.arguments/0`).
+      See the README for more information. Defaults to `[]`.
 
   """
   @spec unbind(Channel.t, Basic.queue, Basic.exchange, keyword) :: :ok | Basic.error


### PR DESCRIPTION
cc @ono 

The idea is to make this easier to consume from the Hexdocs documentation (instead of having to go through the README). Thoughts?