### PR TITLE
Allow for port to be configured as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,32 +245,44 @@ The valid AMQP field types are:
 
 Valid argument names in `Queue.declare` include:
 
-* "x-expires"
-* "x-message-ttl"
-* "x-dead-letter-routing-key"
-* "x-dead-letter-exchange"
-* "x-max-length"
-* "x-max-length-bytes"
+- "x-expires"
+- "x-message-ttl"
+- "x-dead-letter-routing-key"
+- "x-dead-letter-exchange"
+- "x-max-length"
+- "x-max-length-bytes"
 
 Valid argument names in `Basic.consume` include:
 
-* "x-priority"
-* "x-cancel-on-ha-failover"
+- "x-priority"
+- "x-cancel-on-ha-failover"
 
 Valid argument names in `Exchange.declare` include:
 
-* "alternate-exchange"
+- "alternate-exchange"
 
 ## Troubleshooting / FAQ
+
+#### Testing AMQP locally
+
+In order to test the AMQP library locally, you need an instance of RabbitMQ running. The easiest way to do
+that is by using Docker and running the following command in the background:
+
+```
+docker run -p 5672:5672 -p 15672:15672 rabbitmq:3.8-management
+```
+
+With that running in the background, you should be able to run the tests via `mix test`.
 
 #### Connections and Channels
 
 If this is your first time using RabbitMQ, we recommend you to start designing your application like this way:
 
 - Open and manage a single connection for an application
-- Open/close a channel per process (don't share a channel between multiple processes)
 
-Once you saw things in action you can now consider optimising the performance by increasing number of connections etc.
+* Open/close a channel per process (don't share a channel between multiple processes)
+
+Once you see things in action you can now consider optimising the performance by increasing number of connections etc.
 
 Note it's completely safe to share a single connection between multiple processes.
 However it is not recommended to share a channel between multiple processes.

--- a/README.md
+++ b/README.md
@@ -245,34 +245,23 @@ The valid AMQP field types are:
 
 Valid argument names in `Queue.declare` include:
 
-- "x-expires"
-- "x-message-ttl"
-- "x-dead-letter-routing-key"
-- "x-dead-letter-exchange"
-- "x-max-length"
-- "x-max-length-bytes"
+* "x-expires"
+* "x-message-ttl"
+* "x-dead-letter-routing-key"
+* "x-dead-letter-exchange"
+* "x-max-length"
+* "x-max-length-bytes"
 
 Valid argument names in `Basic.consume` include:
 
-- "x-priority"
-- "x-cancel-on-ha-failover"
+* "x-priority"
+* "x-cancel-on-ha-failover"
 
 Valid argument names in `Exchange.declare` include:
 
-- "alternate-exchange"
+* "alternate-exchange"
 
 ## Troubleshooting / FAQ
-
-#### Testing AMQP locally
-
-In order to test the AMQP library locally, you need an instance of RabbitMQ running. The easiest way to do
-that is by using Docker and running the following command in the background:
-
-```
-docker run -p 5672:5672 -p 15672:15672 rabbitmq:3.8-management
-```
-
-With that running in the background, you should be able to run the tests via `mix test`.
 
 #### Connections and Channels
 
@@ -281,7 +270,7 @@ If this is your first time using RabbitMQ, we recommend you to start designing y
 - Open and manage a single connection for an application
 - Open/close a channel per process (don't share a channel between multiple processes)
 
-Once you see things in action you can now consider optimising the performance by increasing number of connections etc.
+Once you saw things in action you can now consider optimising the performance by increasing number of connections etc.
 
 Note it's completely safe to share a single connection between multiple processes.
 However it is not recommended to share a channel between multiple processes.

--- a/README.md
+++ b/README.md
@@ -279,8 +279,7 @@ With that running in the background, you should be able to run the tests via `mi
 If this is your first time using RabbitMQ, we recommend you to start designing your application like this way:
 
 - Open and manage a single connection for an application
-
-* Open/close a channel per process (don't share a channel between multiple processes)
+- Open/close a channel per process (don't share a channel between multiple processes)
 
 Once you see things in action you can now consider optimising the performance by increasing number of connections etc.
 

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -41,7 +41,7 @@ defmodule AMQP.Connection do
     * `:password` - The password of user (defaults to `"guest"`);
     * `:virtual_host` - The name of a virtual host in the broker (defaults to `"/"`);
     * `:host` - The hostname of the broker (defaults to `"localhost"`);
-    * `:port` - The port the broker is listening on as either a string or an integer (defaults to `5672`);
+    * `:port` - The port the broker is listening on (defaults to `5672`);
     * `:channel_max` - The channel_max handshake parameter (defaults to `0`);
     * `:frame_max` - The frame_max handshake parameter (defaults to `0`);
     * `:heartbeat` - The hearbeat interval in seconds (defaults to `10`);
@@ -149,11 +149,11 @@ defmodule AMQP.Connection do
       password: keys_get(options, params, :password),
       virtual_host: keys_get(options, params, :virtual_host),
       host: keys_get(options, params, :host) |> to_charlist(),
-      port: keys_get(options, params, :port) |> normalize_port(),
-      channel_max: keys_get(options, params, :channel_max),
-      frame_max: keys_get(options, params, :frame_max),
-      heartbeat: keys_get(options, params, :heartbeat),
-      connection_timeout: keys_get(options, params, :connection_timeout),
+      port: keys_get(options, params, :port) |> normalize_int_opt(),
+      channel_max: keys_get(options, params, :channel_max) |> normalize_int_opt(),
+      frame_max: keys_get(options, params, :frame_max) |> normalize_int_opt(),
+      heartbeat: keys_get(options, params, :heartbeat) |> normalize_int_opt(),
+      connection_timeout: keys_get(options, params, :connection_timeout) |> normalize_int_opt(),
       ssl_options: keys_get(options, params, :ssl_options),
       client_properties: keys_get(options, params, :client_properties),
       socket_options: keys_get(options, params, :socket_options),
@@ -172,11 +172,11 @@ defmodule AMQP.Connection do
       password: Keyword.get(options, :password, "guest"),
       virtual_host: Keyword.get(options, :virtual_host, "/"),
       host: Keyword.get(options, :host, 'localhost') |> to_charlist(),
-      port: Keyword.get(options, :port, :undefined) |> normalize_port(),
-      channel_max: Keyword.get(options, :channel_max, 0),
-      frame_max: Keyword.get(options, :frame_max, 0),
-      heartbeat: Keyword.get(options, :heartbeat, 10),
-      connection_timeout: Keyword.get(options, :connection_timeout, 50000),
+      port: Keyword.get(options, :port, :undefined) |> normalize_int_opt(),
+      channel_max: Keyword.get(options, :channel_max, 0) |> normalize_int_opt(),
+      frame_max: Keyword.get(options, :frame_max, 0) |> normalize_int_opt(),
+      heartbeat: Keyword.get(options, :heartbeat, 10) |> normalize_int_opt(),
+      connection_timeout: Keyword.get(options, :connection_timeout, 50000) |> normalize_int_opt(),
       ssl_options: Keyword.get(options, :ssl_options, :none),
       client_properties: Keyword.get(options, :client_properties, []),
       socket_options: Keyword.get(options, :socket_options, []),
@@ -188,9 +188,9 @@ defmodule AMQP.Connection do
     )
   end
 
-  # If the port is configured as a string, cast it to an integer
-  defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
-  defp normalize_port(port), do: port
+  # If an integer value is configured as a string, cast it to an integer where applicable
+  defp normalize_int_opt(value) when is_binary(value), do: String.to_integer(value)
+  defp normalize_int_opt(value), do: value
 
   @doc """
   Closes an open Connection.

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -189,7 +189,7 @@ defmodule AMQP.Connection do
   end
 
   # If the port is configured as a string, cast it to an integer
-  defp normalize_port(port) when is_bitstring(port), do: String.to_integer(port)
+  defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
   defp normalize_port(port), do: port
 
   @doc """

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -41,7 +41,7 @@ defmodule AMQP.Connection do
     * `:password` - The password of user (defaults to `"guest"`);
     * `:virtual_host` - The name of a virtual host in the broker (defaults to `"/"`);
     * `:host` - The hostname of the broker (defaults to `"localhost"`);
-    * `:port` - The port the broker is listening on (defaults to `5672`);
+    * `:port` - The port the broker is listening on as either a string or an integer (defaults to `5672`);
     * `:channel_max` - The channel_max handshake parameter (defaults to `0`);
     * `:frame_max` - The frame_max handshake parameter (defaults to `0`);
     * `:heartbeat` - The hearbeat interval in seconds (defaults to `10`);
@@ -148,8 +148,8 @@ defmodule AMQP.Connection do
       username: keys_get(options, params, :username),
       password: keys_get(options, params, :password),
       virtual_host: keys_get(options, params, :virtual_host),
-      host: keys_get(options, params, :host) |> to_charlist,
-      port: keys_get(options, params, :port),
+      host: keys_get(options, params, :host) |> to_charlist(),
+      port: keys_get(options, params, :port) |> normalize_port(),
       channel_max: keys_get(options, params, :channel_max),
       frame_max: keys_get(options, params, :frame_max),
       heartbeat: keys_get(options, params, :heartbeat),
@@ -171,8 +171,8 @@ defmodule AMQP.Connection do
       username: Keyword.get(options, :username, "guest"),
       password: Keyword.get(options, :password, "guest"),
       virtual_host: Keyword.get(options, :virtual_host, "/"),
-      host: Keyword.get(options, :host, 'localhost') |> to_charlist,
-      port: Keyword.get(options, :port, :undefined),
+      host: Keyword.get(options, :host, 'localhost') |> to_charlist(),
+      port: Keyword.get(options, :port, :undefined) |> normalize_port(),
       channel_max: Keyword.get(options, :channel_max, 0),
       frame_max: Keyword.get(options, :frame_max, 0),
       heartbeat: Keyword.get(options, :heartbeat, 10),
@@ -187,6 +187,10 @@ defmodule AMQP.Connection do
         ])
     )
   end
+
+  # If the port is configured as a string, cast it to an integer
+  defp normalize_port(port) when is_bitstring(port), do: String.to_integer(port)
+  defp normalize_port(port), do: port
 
   @doc """
   Closes an open Connection.

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -9,7 +9,12 @@ defmodule ConnectionTest do
   end
 
   test "open connection with host as binary" do
-    assert {:ok, conn} = Connection.open(host: "localhost")
+    assert {:ok, conn} = Connection.open(host: "localhost", port: 5672)
+    assert :ok = Connection.close(conn)
+  end
+
+  test "open connection with port as binary" do
+    assert {:ok, conn} = Connection.open(host: "localhost", port: "5672")
     assert :ok = Connection.close(conn)
   end
 
@@ -31,6 +36,26 @@ defmodule ConnectionTest do
   test "open connection with uri, name, and options" do
     assert {:ok, conn} =
              Connection.open("amqp://nonexistent:5672", "my-connection", host: 'localhost')
+
+    assert :ok = Connection.close(conn)
+  end
+
+  test "open connection with uri, name, port as an integer, and options " do
+    assert {:ok, conn} =
+             Connection.open("amqp://nonexistent", "my-connection",
+               host: 'localhost',
+               port: 5672
+             )
+
+    assert :ok = Connection.close(conn)
+  end
+
+  test "open connection with uri, name, port as a string, and options " do
+    assert {:ok, conn} =
+             Connection.open("amqp://nonexistent", "my-connection",
+               host: 'localhost',
+               port: "5672"
+             )
 
     assert :ok = Connection.close(conn)
   end


### PR DESCRIPTION
This is a quality of life change for configuring connections to RabbitMQ. If the port is provided as a string (which is often the time if the port is configured via an environment variable), a cryptic Erlang authentication error if returned back and it makes it difficult to root cause that the problem was merely a type issue (string vs integer). Attaching the error below when this occurs.

The proposed change is something that is also done in Phoenix for similar reasons: https://github.com/phoenixframework/phoenix/blob/b53813bf3e612077c887f4241a3ff82b41ae9a3f/lib/phoenix/endpoint/cowboy2_adapter.ex#L124-L125

I have also added some README changes to make contributing to `amqp` a bit easier :).

```text
=ERROR REPORT==== 31-Jan-2020::09:34:08.524654 ===
** Generic server <0.241.0> terminating
** Last message in was connect
** When Server state == {<0.240.0>,
                         {amqp_params_network,<<"guest">>,
                             <<"V3ihvPxvBUBPNWzQ37AA6/iZvMYi8yQd25lHVFO+ru5o64ZrBSJV0jFkyL/KsuEw">>,
                             <<"/">>,"localhost",<<"5672">>,0,0,10,50000,none,
                             [fun amqp_auth_mechanisms:plain/3,
                              fun amqp_auth_mechanisms:amqplain/3],
                             [],[]}}
** Reason for termination ==
** {function_clause,
       [{amqp_gen_connection,terminate,
            [{function_clause,
                 [{inet_tcp,getserv,
                      [<<"5672">>],
                      [{file,"inet_tcp.erl"},{line,55}]},
                  {gen_tcp,connect1,4,[{file,"gen_tcp.erl"},{line,176}]},
                  {gen_tcp,connect,4,[{file,"gen_tcp.erl"},{line,163}]},
                  {amqp_network_connection,do_connect,4,
                      [{file,
                           "~/amqp/deps/amqp_client/src/amqp_network_connection.erl"},
                       {line,132}]},
                  {amqp_gen_connection,handle_call,3,
                      [{file,
                           "~/amqp/deps/amqp_client/src/amqp_gen_connection.erl"},
                       {line,174}]},
                  {gen_server,try_handle_call,4,
                      [{file,"gen_server.erl"},{line,661}]},
                  {gen_server,handle_msg,6,
                      [{file,"gen_server.erl"},{line,690}]},
                  {proc_lib,init_p_do_apply,3,
                      [{file,"proc_lib.erl"},{line,249}]}]},
             {<0.240.0>,
              {amqp_params_network,<<"guest">>,
                  <<"V3ihvPxvBUBPNWzQ37AA6/iZvMYi8yQd25lHVFO+ru5o64ZrBSJV0jFkyL/KsuEw">>,
                  <<"/">>,"localhost",<<"5672">>,0,0,10,50000,none,
                  [fun amqp_auth_mechanisms:plain/3,
                   fun amqp_auth_mechanisms:amqplain/3],
                  [],[]}}],
            [{file,
                 "~/amqp/deps/amqp_client/src/amqp_gen_connection.erl"},
             {line,242}]},
        {gen_server,try_terminate,3,[{file,"gen_server.erl"},{line,673}]},
        {gen_server,terminate,10,[{file,"gen_server.erl"},{line,858}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
** Client <0.238.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,167}]},
    {gen_server,call,3,[{file,"gen_server.erl"},{line,219}]},
    {'Elixir.AMQP.Connection',do_open,2,
                              [{file,"lib/amqp/connection.ex"},{line,207}]},
    {'Elixir.ConnectionTest','test open connection with host as binary',1,
                             [{file,"test/connection_test.exs"},{line,12}]},
    {'Elixir.ExUnit.Runner',exec_test,1,
                            [{file,"lib/ex_unit/runner.ex"},{line,355}]},
    {timer,tc,1,[{file,"timer.erl"},{line,166}]},
    {'Elixir.ExUnit.Runner','-spawn_test_monitor/4-fun-1-',4,
                            [{file,"lib/ex_unit/runner.ex"},{line,306}]}]

=CRASH REPORT==== 31-Jan-2020::09:34:08.526813 ===
  crasher:
    initial call: amqp_gen_connection:init/1
    pid: <0.241.0>
    registered_name: []
    exception error: no function clause matching
                     amqp_gen_connection:terminate({function_clause,
                                                    [{inet_tcp,getserv,
                                                      [<<"5672">>],
                                                      [{file,"inet_tcp.erl"},
                                                       {line,55}]},
                                                     {gen_tcp,connect1,4,
                                                      [{file,"gen_tcp.erl"},
                                                       {line,176}]},
                                                     {gen_tcp,connect,4,
                                                      [{file,"gen_tcp.erl"},
                                                       {line,163}]},
                                                     {amqp_network_connection,
                                                      do_connect,4,
                                                      [{file,
                                                        "~/amqp/deps/amqp_client/src/amqp_network_connection.erl"},
                                                       {line,132}]},
                                                     {amqp_gen_connection,
                                                      handle_call,3,
                                                      [{file,
                                                        "~/amqp/deps/amqp_client/src/amqp_gen_connection.erl"},
                                                       {line,174}]},
                                                     {gen_server,
                                                      try_handle_call,4,
                                                      [{file,"gen_server.erl"},
                                                       {line,661}]},
                                                     {gen_server,handle_msg,
                                                      6,
                                                      [{file,"gen_server.erl"},
                                                       {line,690}]},
                                                     {proc_lib,
                                                      init_p_do_apply,3,
                                                      [{file,"proc_lib.erl"},
                                                       {line,249}]}]},
                                                   {<0.240.0>,
                                                    {amqp_params_network,
                                                     <<"guest">>,
                                                     <<"V3ihvPxvBUBPNWzQ37AA6/iZvMYi8yQd25lHVFO+ru5o64ZrBSJV0jFkyL/KsuEw">>,
                                                     <<"/">>,"localhost",
                                                     <<"5672">>,0,0,10,50000,
                                                     none,
                                                     [fun amqp_auth_mechanisms:plain/3,
                                                      fun amqp_auth_mechanisms:amqplain/3],
                                                     [],[]}}) (~amqp/deps/amqp_client/src/amqp_gen_connection.erl, line 242)
      in function  gen_server:try_terminate/3 (gen_server.erl, line 673)
      in call from gen_server:terminate/10 (gen_server.erl, line 858)
    ancestors: [<0.239.0>,amqp_sup,<0.211.0>]
    message_queue_len: 0
    messages: []
    links: [<0.239.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 6772
    stack_size: 27
    reductions: 21699
  neighbours:
```