### PR TITLE
Receive options on queue subscribe and pass to basic consume

### DIFF
--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -202,9 +202,9 @@ defmodule AMQP.Queue do
   """
   @spec subscribe(Channel.t(), Basic.queue(), (String.t(), map -> any)) ::
           {:ok, String.t()} | Basic.error()
-  def subscribe(%Channel{} = channel, queue, fun) when is_function(fun, 2) do
+  def subscribe(%Channel{} = channel, queue, fun, options \\ []) when is_function(fun, 2) do
     consumer_pid = spawn(fn -> do_start_consumer(channel, fun) end)
-    Basic.consume(channel, queue, consumer_pid)
+    Basic.consume(channel, queue, consumer_pid, options)
   end
 
   defp do_start_consumer(channel, fun) do

--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -200,7 +200,7 @@ defmodule AMQP.Queue do
 
   This convenience function will spawn a process and register it using AMQP.Basic.consume.
   """
-  @spec subscribe(Channel.t(), Basic.queue(), (String.t(), map -> any)) ::
+  @spec subscribe(Channel.t(), Basic.queue(), (String.t(), map -> any), keyword) ::
           {:ok, String.t()} | Basic.error()
   def subscribe(%Channel{} = channel, queue, fun, options \\ []) when is_function(fun, 2) do
     consumer_pid = spawn(fn -> do_start_consumer(channel, fun) end)


### PR DESCRIPTION
Added options to Queue/subscriber to pass options to Basic/consume.
I used this to set a custom consumer_tag.