### PR TITLE
Connection/1 keyword list to contain a connection_name

### DIFF
--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -11,13 +11,27 @@ defmodule AMQP.Connection do
   @type t :: %Connection{pid: pid}
 
   @doc """
-  Opens a new connection without a name.
+  Opens a new connection. `connection_name` can be passed in as an option when given a keyword list.
 
   Behaves exactly like `open(options_or_uri, :undefined)`. See `open/2`.
   """
   @spec open(keyword | String.t()) :: {:ok, t()} | {:error, atom()} | {:error, any()}
-  def open(options_or_uri \\ []) when is_binary(options_or_uri) or is_list(options_or_uri) do
-    open(options_or_uri, :undefined)
+  def open(options \\ [])
+
+  def open(uri) when is_binary(uri) do
+    open(uri, :undefined)
+  end
+
+  def open(options) when is_list(options) do
+    options
+    |> Keyword.get_and_update(:connection_name, fn _ -> :pop end)
+    |> case do
+      {nil, options} ->
+        open(options, :undefined)
+
+      {connection_name, options} ->
+        open(options, connection_name)
+    end
   end
 
   @doc """


### PR DESCRIPTION
Hey y'all. Long time user, first time contributor. 😄 
Not sure how y'all feel about this but I was wondering if this little tweak could get in. Yeah I know that there's a `open/2` to account for the name. However several other libs that depend on AMQP just use `open/1` and then pass along the Keyword list. So I was thinking it would be super duper nice to just allow `connection_name` in the config.
I can add a test or two if this tweak is acceptable 🤗 
Thanks for all the awesome work on this lib!

<img width="813" alt="Screen Shot 2020-04-29 at 2 35 41 PM" src="https://user-images.githubusercontent.com/729514/80638895-c9f6b380-8a26-11ea-978f-ccd7af12a6e3.png">
<img width="232" alt="Screen Shot 2020-04-29 at 2 36 35 PM" src="https://user-images.githubusercontent.com/729514/80638930-dc70ed00-8a26-11ea-8084-5ba6907095f9.png">
