### PR TITLE
Take connection_name from options parameter and make it a new standard

### DIFF
--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -57,13 +57,13 @@ defmodule AMQP.Connection do
     * `:auth_mechanisms` - A list of authentication of SASL authentication mechanisms to use. \
                           See https://www.rabbitmq.com/access-control.html#mechanisms and https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl \
                           for descriptions of the available options;
-    * `:connection_name` - A human-readable string that will be displayed in the management UI. \
+    * `:name` - A human-readable string that will be displayed in the management UI. \
                           Connection names do not have to be unique and cannot be used as connection identifiers \
                           (defaults to `:undefined`).
 
   ## Examples
 
-      iex> options = [host: "localhost", port: 5672, virtual_host: "/", username: "guest", password: "guest", connection_name: "my-conn"]
+      iex> options = [host: "localhost", port: 5672, virtual_host: "/", username: "guest", password: "guest", name: "my-conn"]
       iex> AMQP.Connection.open(options)
       {:ok, %AMQP.Connection{}}
 
@@ -109,10 +109,10 @@ defmodule AMQP.Connection do
       iex> AMQP.Connection.open("amqp://guest:guest@localhost", "my-connection", options)
       {:ok, %AMQP.Connection{}}
 
-  However connection_name parameter is now deprecated and might not be supported in the future versions.
-  You are recommented to pass it with `:connection_name` option instead:
+  However the connection name parameter is now deprecated and might not be supported in the future versions.
+  You are recommented to pass it with `:name` option instead:
 
-      iex> AMQP.Connection.open("amqp://guest:guest@localhost", connection_name: "my-connection")
+      iex> AMQP.Connection.open("amqp://guest:guest@localhost", name: "my-connection")
       {:ok, %AMQP.Connection{}}
   """
   @spec open(String.t() | keyword, keyword | String.t() | :undefined) ::
@@ -139,7 +139,7 @@ defmodule AMQP.Connection do
   end
 
   @doc false
-  @deprecated "Use :connection_name in open/2 instead"
+  @deprecated "Use :name in open/2 instead"
   @spec open(String.t(), String.t() | :undefined, keyword) ::
           {:ok, t()} | {:error, atom()} | {:error, any()}
   def open(uri, name, options) when is_binary(uri) and is_list(options) do
@@ -162,8 +162,8 @@ defmodule AMQP.Connection do
 
   # take name from options
   defp take_connection_name(options) do
-    name = options[:connection_name] || :undefined
-    options = Keyword.delete(options, :connection_name)
+    name = options[:name] || :undefined
+    options = Keyword.delete(options, :name)
     {name, options}
   end
 

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -106,7 +106,7 @@ defmodule AMQP.Connection do
       iex> AMQP.Connection.open("amqp://guest:guest@localhost", "my-connection")
       {:ok, %AMQP.Connection{}}
 
-      iex> AMQP.Connection.open("amqp://guest:guest@localhost", options, "my-connection")
+      iex> AMQP.Connection.open("amqp://guest:guest@localhost", "my-connection", options)
       {:ok, %AMQP.Connection{}}
 
   However connection_name parameter is now deprecated and might not be supported in the future versions.

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -33,16 +33,9 @@ defmodule ConnectionTest do
     assert :ok = Connection.close(conn)
   end
 
-  test "open connection with uri, name, and options" do
+  test "open connection with uri, port as an integer, and options " do
     assert {:ok, conn} =
-             Connection.open("amqp://nonexistent:5672", "my-connection", host: 'localhost')
-
-    assert :ok = Connection.close(conn)
-  end
-
-  test "open connection with uri, name, port as an integer, and options " do
-    assert {:ok, conn} =
-             Connection.open("amqp://nonexistent", "my-connection",
+             Connection.open("amqp://nonexistent",
                host: 'localhost',
                port: 5672
              )
@@ -50,20 +43,26 @@ defmodule ConnectionTest do
     assert :ok = Connection.close(conn)
   end
 
-  test "open connection with uri, name, port as a string, and options" do
+  test "open connection with uri, port as a string, and options" do
     assert {:ok, conn} =
-             Connection.open("amqp://nonexistent", "my-connection",
+             Connection.open("amqp://nonexistent",
                host: 'localhost',
                port: "5672"
              )
 
-    assert get_connection_name(conn) == "my-connection"
     assert :ok = Connection.close(conn)
   end
 
   test "open connection with name in options" do
     assert {:ok, conn} = Connection.open("amqp://localhost", connection_name: "my-connection")
     assert get_connection_name(conn) == "my-connection"
+    assert :ok = Connection.close(conn)
+  end
+
+  test "open connection with uri, name, and options (deprected but still spported)" do
+    assert {:ok, conn} =
+             Connection.open("amqp://nonexistent:5672", "my-connection", host: 'localhost')
+
     assert :ok = Connection.close(conn)
   end
 

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -54,7 +54,7 @@ defmodule ConnectionTest do
   end
 
   test "open connection with name in options" do
-    assert {:ok, conn} = Connection.open("amqp://localhost", connection_name: "my-connection")
+    assert {:ok, conn} = Connection.open("amqp://localhost", name: "my-connection")
     assert get_connection_name(conn) == "my-connection"
     assert :ok = Connection.close(conn)
   end

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -56,6 +56,7 @@ defmodule ConnectionTest do
                host: 'localhost',
                port: "5672"
              )
+
     assert get_connection_name(conn) == "my-connection"
     assert :ok = Connection.close(conn)
   end
@@ -80,7 +81,7 @@ defmodule ConnectionTest do
   defp get_connection_name(conn) do
     params = :amqp_connection.info(conn.pid, [:amqp_params])[:amqp_params]
     amqp_params_network(client_properties: props) = params
-    {_, _, name} = Enum.find(props, fn ({key, _type, _value}) -> key == "connection_name" end)
+    {_, _, name} = Enum.find(props, fn {key, _type, _value} -> key == "connection_name" end)
     name
   end
 end


### PR DESCRIPTION
Additional work for #165. Taking connection_name from options is more intuitive and concise for `Connection.open`. Therefore this PR makes it as a new standard while supporting a backward compatibility.

1. Support `connection_name` option in `Connection.open/1` and `Connection.open/2`
2. Deprecated connection_name parameter on `Connection.open/*` and recommend to use `options`
3. Still support connection_name parameter to support backward compatibility