### PR TITLE
Named connections and channels

### DIFF
--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -1,5 +1,7 @@
 defmodule AMQP.Application do
-  @moduledoc false
+  @moduledoc """
+  Provides access to configured connections and channels.
+  """
 
   use Application
   require Logger
@@ -78,5 +80,160 @@ defmodule AMQP.Application do
       {:error, {:not_found, _}} -> :ok
       error -> error
     end
+  end
+
+  @doc """
+  Provides an easy way to access an AMQP connection.
+
+  The connection will be monitored by AMQP's GenServer and it will automatically try to reconnect when the connection is gone.
+
+  ## Usage
+
+  When you want to have a single connection in your app:
+
+      config :amqp, connection: [
+          url: "amqp://guest:guest@localhost:15672"
+        ]
+
+  You can also use any options available on `AMQP.Connection.open/2`:
+
+      config :amqp, connection: [
+          host: "localhost",
+          port: 15672
+          username: "guest",
+          password: "guest"
+        ]
+
+  Then the connection will be open at the start of the application and you can access via this function.
+
+      iex> {:ok, conn} = AMQP.Application.get_connection()
+
+  By default, it tries to connect to your local RabbitMQ. You can simply pass the empty keyword list too:
+
+      config :amqp, connection: [] # == [url: "amqp://0.0.0.0"]
+
+  You can set up multiple connections wth `:connections` key:
+
+      config :amqp, connections: [
+          business_report: [
+            url: "amqp://host1"
+          ],
+          analytics: [
+            url: "amqp://host2"
+          ]
+        ]
+
+  Then you can access each connection with its name.
+
+      iex> {:ok, conn1} = AMQP.Application.get_connection(:business_report)
+      iex> {:ok, conn2} = AMQP.Application.get_connection(:analytics)
+
+  The defaut name is :default so These two configurations are equivalent:
+
+      config :amqp, connection: []
+      config :amqp, connections: [default: []]
+
+  ## Configuration options
+
+  * `:retry_interval` - The retry interval in milliseconds when the connection is failed to open (default `5000`)
+  * `:url` - AMQP URI for the connection
+
+  See also `AMQP.Connection.open/2` for all available options.
+  """
+  @spec get_connection(binary | atom) :: {:ok, AMQP.Connection.t()} | {:error, any}
+  def get_connection(name \\ :default) do
+    AMQP.Application.Connection.get_connection(name)
+  end
+
+  @doc """
+  Provides an easy way to access an AMQP channel.
+
+  AMQP.Application provides a wrapper on top of `AMQP.Channel` with .
+  The channel will be monitored by AMQP's GenServer and it will automatically try to reopen when the channel is gone.
+
+  ## Usage
+
+  When you want to have a single channel in your app:
+
+      config :amqp,
+        connection: [url: "amqp://guest:guest@localhost:15672"],
+        channel: []
+
+  Then the channel will be open at the start of the application and you can access it via this function.
+
+      iex> {:ok, chan} = AMQP.Application.get_channel()
+
+  You can also set up multiple channels wth `:channels` key:
+
+      config :amqp,
+        connections: [
+          business_report: [url: "amqp://host1"],
+          analytics: [url: "amqp://host2"]
+        ],
+        channels: [
+          bisiness_report: [connection: :business_report],
+          analytics: [connection: :analytics]
+        ]
+
+  Then you can access each channel with its name.
+
+      iex> {:ok, conn1} = AMQP.Application.get_channel(:business_report)
+      iex> {:ok, conn2} = AMQP.Application.get_channel(:analytics)
+
+  You can also have multiple channels for a single connection.
+
+      config :amqp,
+        connection: [],
+        channels: [
+          consumer: [],
+          producer: []
+        ]
+
+  ## Configuration options
+
+  * `:connection` - The connection name configured with `connection` or `connections` (default `:default`)
+  * `:retry_interval` - The retry interval in milliseconds when the channel is failed to open (default `5000`)
+
+  ## Caveat
+
+  Although AMQP will reopen the named channel automatically when it is closed for some reasons,
+  your application still needs to monitor the channel for a consumer process.
+  Be aware the channel reponed doesn't automatically recover the subscription of your consumer 
+
+  Here is a sample GenServer module that monitors the channel and re-subscribe the channel.
+
+      defmodule AppConsumer do
+        use GenServer
+        @channel :default
+        @queue "myqueue"
+
+        ....
+
+        def handle_info(:subscribe, state) do
+          subscribe()
+          {noreply, state}
+        end
+
+        def handle_info({:DOWN, _, :process, pid, reason}, state) do
+          send(self(), :subscribe)
+          {:noreply, state}
+        end
+
+        defp subscribe() do
+          case AMQP.Application.get_channel(@channel) do
+            {:ok, chan} ->
+              Process.monitor(chan.pid)
+              AMQP.Basic.consume(@channel, @queue)
+
+            _error ->
+              Process.send_after(self(), :subscribe, 1000)
+              {:error, :retrying}
+          end
+        end
+      end
+  """
+  @spec get_channel(binary | atom) :: {:ok, AMQP.Channel.t()} | {:error, any}
+  def get_channel(name \\ :default) do
+    AMQP.Application.Channel.get_channel(name)
   end
 end

--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -123,7 +123,7 @@ defmodule AMQP.Application.Channel do
     end
   end
 
-  def handle_info({:DOWN, _, :process, _pid, reason}, state) do
+  def handle_info({:DOWN, _, :process, _pid, reason}, _state) do
     # Stop GenServer. Will be restarted by Supervisor.
     {:stop, {:channel_gone, reason}, nil}
   end

--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -1,0 +1,130 @@
+defmodule AMQP.Application.Channel do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+  alias AMQP.{Channel, Connection}
+
+  @default_interval 5_000
+
+  @doc """
+  Starts a GenServer process linked to the current process.
+
+  ## Examples
+
+  Combines name and retry interval with the connection options.
+
+      iex> opts = [proc_name: :my_chan, retry_interval: 10_000, connection: :my_conn]
+      iex> :ok = AMQP.Application.Channel.start_link(opts)
+      iex> {:ok, chan} = AMQP.Application.Connection.get_connection(:my_chan)
+
+  If you omit the proc_name, it uses :default.
+
+      iex> :ok = AMQP.Application.Channel.start_link([])
+      iex> {:ok, chan} = AMQP.Application.Connection.get_channel()
+      iex> {:ok, chan} = AMQP.Application.Connection.get_channel(:default)
+  """
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts) do
+    {name, init_arg} = link_opts_to_init_arg(opts)
+
+    GenServer.start_link(__MODULE__, init_arg, name: name)
+  end
+
+  defp link_opts_to_init_arg(opts) do
+    proc_name = Keyword.get(opts, :proc_name, :default)
+    server_name = get_server_name(proc_name)
+    retry_interval = Keyword.get(opts, :retry_interval, @default_interval)
+    connection = Keyword.get(opts, :connection, proc_name)
+
+    init_arg = %{
+      retry_interval: retry_interval,
+      connection: connection,
+      name: proc_name,
+      channel: nil
+    }
+
+    {server_name, init_arg}
+  end
+
+  @doc """
+  Returns a GenServer reference for the channel name
+  """
+  @spec get_server_name(binary | atom) :: binary
+  def get_server_name(name) do
+    :"#{__MODULE__}::#{name}"
+  end
+
+  @doc false
+  def get_state(name \\ :default) do
+    GenServer.call(get_server_name(name), :get_state)
+  end
+
+  @doc """
+  Returns pid for the server referred by the name.
+
+  It is a wrapper of `GenServer.whereis/1`.
+  """
+  @spec whereis(binary() | atom()) :: pid() | {atom(), node()} | nil
+  def whereis(name) do
+    name
+    |> get_server_name()
+    |> GenServer.whereis()
+  end
+
+  @doc """
+  Returns a channel referred by the name.
+  """
+  @spec get_channel(binary | atom) :: {:ok, Connection.t()} | {:error, any}
+  def get_channel(name \\ :default) do
+    case GenServer.call(get_server_name(name), :get_channel) do
+      nil -> {:error, :channel_not_ready}
+      channel -> {:ok, channel}
+    end
+  end
+
+  @impl true
+  def init(state) do
+    send(self(), :open)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call(:get_channel, _, state) do
+    {:reply, state[:channel], state}
+  end
+
+  @impl true
+  def handle_info(:open, state) do
+    case AMQP.Application.Connection.get_connection(state[:connection]) do
+      {:ok, conn} ->
+        case Channel.open(conn) do
+          {:ok, chan} ->
+            Process.monitor(chan.pid)
+            {:noreply, %{state | channel: chan}}
+
+          {:error, error} ->
+            Logger.error("Failed to open an AMQP channel(#{state[:name]}) - #{inspect(error)}")
+            Process.send_after(self(), :open, state[:retry_interval])
+            {:noreply, state}
+        end
+
+      _error ->
+        Logger.error(
+          "Failed to open an AMQP channel(#{state[:name]}). Connection (#{state[:connection]}) is not ready."
+        )
+
+        Process.send_after(self(), :open, state[:retry_interval])
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, _, :process, _pid, reason}, state) do
+    # Stop GenServer. Will be restarted by Supervisor.
+    {:stop, {:channel_gone, reason}, nil}
+  end
+end

--- a/lib/amqp/application/connection.ex
+++ b/lib/amqp/application/connection.ex
@@ -1,0 +1,122 @@
+defmodule AMQP.Application.Connection do
+  @moduledoc """
+
+  """
+
+  use GenServer
+  require Logger
+  alias AMQP.Connection
+
+  @default_interval 5_000
+
+  @doc """
+  Starts a GenServer process linked to the current process.
+
+  It expects options to be a combination of connection args, proc_name and retry_interval.
+
+  ## Examples
+
+  Combines name and retry interval with the connection options.
+
+      iex> opts = [proc_name: :my_conn, retry_interval: 10_000, host: "localhost"]
+      iex> :ok = AMQP.Application.Connection.start_link(opts)
+      iex> {:ok, conn} = AMQP.Application.Connection.get_connection(:my_conn)
+
+  Passes URL instead of options and use a default proc name when you need only a single connection.
+
+      iex> opts = [url: "amqp://guest:guest@localhost"]
+      iex> {:ok, conn} = AMQP.Application.Connection.get_connection()
+      iex> {:ok, conn} = AMQP.Application.Connection.get_connection(:default)
+  """
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts) do
+    {name, init_arg} = link_opts_to_init_arg(opts)
+
+    GenServer.start_link(__MODULE__, init_arg, name: name)
+  end
+
+  defp link_opts_to_init_arg(opts) do
+    proc_name = Keyword.get(opts, :proc_name, :default)
+    server_name = get_server_name(proc_name)
+    retry_interval = Keyword.get(opts, :retry_interval, @default_interval)
+    open_arg = Keyword.drop(opts, [:proc_name, :retry_interval])
+
+    init_arg = %{
+      retry_interval: retry_interval,
+      open_arg: open_arg,
+      name: proc_name,
+      connection: nil
+    }
+
+    {server_name, init_arg}
+  end
+
+  @doc """
+  Returns a GenServer reference for the connection name
+  """
+  @spec get_server_name(binary | atom) :: binary
+  def get_server_name(name) do
+    :"amqp_connection_#{name}"
+  end
+
+  @doc false
+  def get_state(name \\ :default) do
+    GenServer.call(get_server_name(name), :get_state)
+  end
+
+  @doc """
+  Returns a connection referred by the name.
+  """
+  @spec get_connection(binary | atom) :: {:ok, Connection.t()} | {:error, any}
+  def get_connection(name \\ :default) do
+    case GenServer.call(get_server_name(name), :get_connection) do
+      nil -> {:error, :not_connected}
+      conn -> {:ok, conn}
+    end
+  end
+
+  @impl true
+  def init(state) do
+    send(self(), :connect)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call(:get_connection, _, state) do
+    {:reply, state[:connection], state}
+  end
+
+  @impl true
+  def handle_info(:connect, state) do
+    case do_open(state[:open_arg]) do
+      {:ok, conn} ->
+        # Get notifications when the connection goes down
+        Process.monitor(conn.pid)
+        {:noreply, %{state | connection: conn}}
+
+      {:error, _} ->
+        Logger.error("Failed to connect to AMQP server (#{state[:name]}). Retrying later...")
+
+        # Retry later
+        Process.send_after(self(), :connect, state[:retry_interval])
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, _, :process, _pid, reason}, _) do
+    # Stop GenServer. Will be restarted by Supervisor.
+    {:stop, {:connection_lost, reason}, nil}
+  end
+
+  defp do_open(options) do
+    if url = options[:url] do
+      Connection.open(url, Keyword.delete(options, :url))
+    else
+      Connection.open(options)
+    end
+  end
+end

--- a/lib/amqp/application/connection.ex
+++ b/lib/amqp/application/connection.ex
@@ -1,5 +1,7 @@
 defmodule AMQP.Application.Connection do
   @moduledoc false
+  # This module will stay as a private module at least during 2.0.x.
+  # There might be non backward compatible changes on this module on 2.1.x.
 
   use GenServer
   require Logger
@@ -100,7 +102,11 @@ defmodule AMQP.Application.Connection do
   end
 
   def handle_call(:get_connection, _, state) do
-    {:reply, state[:connection], state}
+    if state[:connection] && Process.alive?(state[:connection].pid) do
+      {:reply, state[:connection], state}
+    else
+      {:reply, nil, state}
+    end
   end
 
   @impl true

--- a/test/application/channel_test.exs
+++ b/test/application/channel_test.exs
@@ -1,0 +1,34 @@
+defmodule AMQP.Application.ChnnelTest do
+  use ExUnit.Case
+  alias AMQP.Application.Connection, as: AppConn
+  alias AMQP.Application.Channel, as: AppChan
+
+  setup do
+    {:ok, app_conn_pid} = AppConn.start_link([])
+
+    on_exit(fn ->
+      Process.exit(app_conn_pid, :normal)
+    end)
+
+    [app_conn: app_conn_pid]
+  end
+
+  test "opens and accesses channel" do
+    opts = [connection: :default, proc_name: :test_chan]
+    {:ok, pid} = AppChan.start_link(opts)
+
+    assert {:ok, %AMQP.Channel{}} = AppChan.get_channel(:test_chan)
+    Process.exit(pid, :normal)
+  end
+
+  test "reconnects when the channel is gone" do
+    opts = [connection: :default, proc_name: :test_chan]
+    {:ok, _pid} = AppChan.start_link(opts)
+    {:ok, %AMQP.Channel{} = chan1} = AppChan.get_channel(:test_chan)
+    AMQP.Channel.close(chan1)
+    :timer.sleep(50)
+
+    assert {:ok, %AMQP.Channel{} = chan2} = AppChan.get_channel(:test_chan)
+    refute chan1 == chan2
+  end
+end

--- a/test/application/connection_test.exs
+++ b/test/application/connection_test.exs
@@ -1,0 +1,24 @@
+defmodule AMQP.Application.ConnectionTest do
+  use ExUnit.Case
+  alias AMQP.Application.Connection, as: AppConn
+
+  test "opens and accesses to connections" do
+    opts = [proc_name: :my_conn, retry_interval: 10_000, url: "amqp://guest:guest@localhost"]
+    {:ok, pid} = AppConn.start_link(opts)
+
+    {:ok, conn} = AppConn.get_connection(:my_conn)
+    assert %AMQP.Connection{} = conn
+
+    Process.exit(pid, :normal)
+  end
+
+  test "reconnects when the connection is gone" do
+    {:ok, _pid} = AppConn.start_link([])
+    {:ok, %AMQP.Connection{} = conn1} = AppConn.get_connection()
+    AMQP.Connection.close(conn1)
+    :timer.sleep(50)
+
+    assert {:ok, %AMQP.Connection{} = conn2} = AppConn.get_connection()
+    refute conn1 == conn2
+  end
+end

--- a/test/application/connection_test.exs
+++ b/test/application/connection_test.exs
@@ -2,7 +2,7 @@ defmodule AMQP.Application.ConnectionTest do
   use ExUnit.Case
   alias AMQP.Application.Connection, as: AppConn
 
-  test "opens and accesses to connections" do
+  test "opens and accesses connections" do
     opts = [proc_name: :my_conn, retry_interval: 10_000, url: "amqp://guest:guest@localhost"]
     {:ok, pid} = AppConn.start_link(opts)
 


### PR DESCRIPTION
Provide named connections and channels which can be loaded from configuration. Provide an easy access to users who are new to the library.