### PR TITLE
Document the return type of Queue.declare

### DIFF
--- a/lib/amqp/queue.ex
+++ b/lib/amqp/queue.ex
@@ -29,7 +29,10 @@ defmodule AMQP.Queue do
       See the README for more information. Defaults to `[]`.
 
   """
-  @spec declare(Channel.t(), Basic.queue(), keyword) :: {:ok, map} | :ok | Basic.error()
+  @spec declare(Channel.t(), Basic.queue(), keyword) ::
+          {:ok, %{queue: Basic.queue(), message_count: integer, consumer_count: integer}}
+          | :ok
+          | Basic.error()
   def declare(%Channel{pid: pid}, queue \\ "", options \\ []) do
     nowait = get_nowait(options)
 


### PR DESCRIPTION
While using `AMQP.Queue.declare` with only the first parameter I couldn't find any documentation for the return value.