### PR TITLE
Handling shutdown reason in direct_consumer, and clean up consumer afterwards.

### DIFF
--- a/lib/amqp/direct_consumer.ex
+++ b/lib/amqp/direct_consumer.ex
@@ -60,10 +60,20 @@ defmodule AMQP.DirectConsumer do
   end
 
   @impl true
+  def handle_deliver(_method, _msg, nil) do
+    {:error, :no_consumer, nil}
+  end
+
+  @impl true
   def handle_deliver(method, message, consumer) do
     send(consumer, compose_message(method, message))
 
     {:ok, consumer}
+  end
+
+  @impl true
+  def handle_deliver(_, _args, _ctx, nil) do
+    {:error, :no_consumer, nil}
   end
 
   @impl true
@@ -74,8 +84,9 @@ defmodule AMQP.DirectConsumer do
   end
 
   @impl true
-  def handle_info({:DOWN, _mref, :process, consumer, :normal}, consumer) do
-    {:ok, consumer}
+  def handle_info({:DOWN, _mref, :process, _consumer, reason}, _consumer)
+      when reason in [:normal, :shutdown] do
+    {:ok, nil}
   end
 
   def handle_info({:DOWN, _mref, :process, consumer, info}, consumer) do

--- a/lib/amqp/direct_consumer.ex
+++ b/lib/amqp/direct_consumer.ex
@@ -27,6 +27,7 @@ defmodule AMQP.DirectConsumer do
   def init({pid, options}) do
     _ref = Process.monitor(pid)
     ignore_shutdown = Keyword.get(options, :ignore_shutdown, false)
+
     {:ok, %{consumer: pid, ignore_shutdown: ignore_shutdown}}
   end
 
@@ -41,24 +42,28 @@ defmodule AMQP.DirectConsumer do
   @impl true
   def handle_consume_ok(method, _args, state) do
     send(state.consumer, compose_message(method))
+
     {:ok, state}
   end
 
   @impl true
   def handle_cancel(method, state) do
     send(state.consumer, compose_message(method))
+
     {:ok, state}
   end
 
   @impl true
   def handle_cancel_ok(method, _args, state) do
     send(state.consumer, compose_message(method))
+
     {:ok, state}
   end
 
   @impl true
   def handle_server_cancel(method, state) do
     send(state.consumer, compose_message(method))
+
     {:ok, state}
   end
 
@@ -102,6 +107,7 @@ defmodule AMQP.DirectConsumer do
 
   def handle_info(down = {:DOWN, _, _, _, _}, state) do
     send(state.consumer, down)
+
     {:ok, state}
   end
 

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -61,7 +61,7 @@ defmodule ConnectionTest do
 
   test "open connection with uri, name, and options (deprected but still spported)" do
     assert {:ok, conn} =
-             Connection.open("amqp://nonexistent:5672", "my-connection", host: 'localhost')
+             Connection.open("amqp://nonexistent:5672", name: "my-connection", host: 'localhost')
 
     assert :ok = Connection.close(conn)
   end


### PR DESCRIPTION
Hey there,

We encountered countless `:consumer_died` error logs in our test cases, and this pr aims to rectify that, and additionally to fix another possible headache for other users with disorderly shutdowns.

The changes are that we handle :shutdown and :normal exit reasons to avoid messy error logs, and return nil as the consumer. Now we also need to handle that, so that no message is being forwarded anymore in case if the channel was not shut down, if you were to try to send messages then we return an error.

I hope this makes sense.