### PR TITLE
Fix error in docs for sample consumer GenServer

### DIFF
--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -211,7 +211,7 @@ defmodule AMQP.Application do
 
         def handle_info(:subscribe, state) do
           subscribe()
-          {noreply, state}
+          {:noreply, state}
         end
 
         def handle_info({:DOWN, _, :process, pid, reason}, state) do


### PR DESCRIPTION
The sample consumer gen server has a undefined variable on one `handle_info` return.