### PR TITLE
[FIX][189] Support :closing case in AMQP.Channel.open/2

### DIFF
--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -120,11 +120,6 @@ defmodule AMQP.Application.Channel do
             Logger.error("Failed to open an AMQP channel(#{state[:name]}) - #{inspect(error)}")
             Process.send_after(self(), :open, state[:retry_interval])
             {:noreply, state}
-
-          error ->
-            Logger.error("Failed to open an AMQP channel(#{state[:name]}) - #{inspect(error)}")
-            Process.send_after(self(), :open, state[:retry_interval])
-            {:noreply, state}
         end
 
       _error ->

--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -1,5 +1,6 @@
 defmodule AMQP.Application.Channel do
   @moduledoc false
+
   # This module will stay as a private module at least during 2.0.x.
   # There might be non backward compatible changes on this module on 2.1.x.
 
@@ -116,6 +117,11 @@ defmodule AMQP.Application.Channel do
             {:noreply, %{state | channel: chan, monitor_ref: ref}}
 
           {:error, error} ->
+            Logger.error("Failed to open an AMQP channel(#{state[:name]}) - #{inspect(error)}")
+            Process.send_after(self(), :open, state[:retry_interval])
+            {:noreply, state}
+
+          error ->
             Logger.error("Failed to open an AMQP channel(#{state[:name]}) - #{inspect(error)}")
             Process.send_after(self(), :open, state[:retry_interval])
             {:noreply, state}

--- a/lib/amqp/channel.ex
+++ b/lib/amqp/channel.ex
@@ -36,8 +36,7 @@ defmodule AMQP.Channel do
   defp do_open_channel(conn, nil) do
     case :amqp_connection.open_channel(conn.pid) do
       {:ok, chan_pid} -> {:ok, %Channel{conn: conn, pid: chan_pid}}
-      {:error, error} -> {:error, error}
-      :closing -> {:error, :closing}
+      error -> {:error, error}
     end
   end
 
@@ -46,11 +45,8 @@ defmodule AMQP.Channel do
       {:ok, chan_pid} ->
         {:ok, %Channel{conn: conn, pid: chan_pid, custom_consumer: custom_consumer}}
 
-      {:error, error} ->
+      error ->
         {:error, error}
-
-      :closing ->
-        {:error, :closing}
     end
   end
 end

--- a/lib/amqp/channel.ex
+++ b/lib/amqp/channel.ex
@@ -17,8 +17,7 @@ defmodule AMQP.Channel do
   `:amqp_connection.open_channel/2` for more details and `AMQP.DirectConsumer` for an example of a
   custom consumer.
   """
-  @spec open(Connection.t(), custom_consumer | nil) ::
-          {:ok, Channel.t()} | {:error, any} | any
+  @spec open(Connection.t(), custom_consumer | nil) :: {:ok, Channel.t()} | {:error, any}
   def open(%Connection{} = conn, custom_consumer \\ {SelectiveConsumer, self()}) do
     do_open_channel(conn, custom_consumer)
   end
@@ -37,7 +36,8 @@ defmodule AMQP.Channel do
   defp do_open_channel(conn, nil) do
     case :amqp_connection.open_channel(conn.pid) do
       {:ok, chan_pid} -> {:ok, %Channel{conn: conn, pid: chan_pid}}
-      error -> error
+      {:error, error} -> {:error, error}
+      :closing -> {:error, :closing}
     end
   end
 
@@ -46,8 +46,11 @@ defmodule AMQP.Channel do
       {:ok, chan_pid} ->
         {:ok, %Channel{conn: conn, pid: chan_pid, custom_consumer: custom_consumer}}
 
-      error ->
-        error
+      {:error, error} ->
+        {:error, error}
+
+      :closing ->
+        {:error, :closing}
     end
   end
 end

--- a/lib/amqp/channel.ex
+++ b/lib/amqp/channel.ex
@@ -17,7 +17,8 @@ defmodule AMQP.Channel do
   `:amqp_connection.open_channel/2` for more details and `AMQP.DirectConsumer` for an example of a
   custom consumer.
   """
-  @spec open(Connection.t(), custom_consumer | nil) :: {:ok, Channel.t()} | {:error, any}
+  @spec open(Connection.t(), custom_consumer | nil) ::
+          {:ok, Channel.t()} | {:error, any} | any
   def open(%Connection{} = conn, custom_consumer \\ {SelectiveConsumer, self()}) do
     do_open_channel(conn, custom_consumer)
   end

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -59,7 +59,7 @@ defmodule ConnectionTest do
     assert :ok = Connection.close(conn)
   end
 
-  test "open connection with uri, name, and options (deprected but still spported)" do
+  test "open connection with uri, name, and options (deprecated but still supported)" do
     assert {:ok, conn} =
              Connection.open("amqp://nonexistent:5672", "my-connection", host: 'localhost')
 


### PR DESCRIPTION
Fixes #189 

Not sure this is the best approach, but I didn't want to affect how the existing tuple clause is handled (as it would change what is logged).

I also see `Basic.error` has a variant with a `:closing` atom in it, so I'm wondering if I should use that somehow.

Finally, I would love advice on how to write a test for this.