### PR TITLE
fix docs error

### DIFF
--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -243,7 +243,8 @@ defmodule AMQP.Application do
           case AMQP.Application.get_channel(@channel) do
             {:ok, chan} ->
               Process.monitor(chan.pid)
-              AMQP.Basic.consume(@channel, @queue)
+              {:ok, _consumer_tag} = AMQP.Basic.consume(@channel, @queue)
+              {:ok, chan}
 
             _error ->
               Process.send_after(self(), :subscribe, 1000)


### PR DESCRIPTION
`subscribe/0` is expected to return `{:ok, chan}`
it returns `{:ok, consumer_tag}` due to `Basic.consume/2`

bug introduced [here](https://git.io/JWAnK) when the return value of
`subscribe/0` was explicitly pattern matched.