### PR TITLE
Catching exits from GenServer, so if it is busy reconnecting, caller doesn't exit.

### DIFF
--- a/lib/amqp/application/connection.ex
+++ b/lib/amqp/application/connection.ex
@@ -95,6 +95,9 @@ defmodule AMQP.Application.Connection do
       nil -> {:error, :not_connected}
       conn -> {:ok, conn}
     end
+  catch
+    :exit, {:timeout, _} ->
+      {:error, :timeout}
   end
 
   @impl true


### PR DESCRIPTION
While AMQP is busy reconnecting, there's a chance that calls to `AMQP.Application.get_connection/0` exits. So to avoid forcing the caller to handle exits, the same is already made from inside the function, returning a proper `{:error, :timeout}`.