### PR TITLE
Catch more GenServer.call timeout error

### DIFF
--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -62,6 +62,8 @@ defmodule AMQP.Application.Channel do
   @doc false
   def get_state(name \\ :default) do
     GenServer.call(get_server_name(name), :get_state)
+  catch
+    :exit, {:timeout, _} -> %{}
   end
 
   @doc """
@@ -85,6 +87,11 @@ defmodule AMQP.Application.Channel do
       nil -> {:error, :channel_not_ready}
       channel -> {:ok, channel}
     end
+  catch
+    :exit, {:timeout, _} ->
+      # This would happen when the connection or channel is stuck when opening.
+      # See handle_info(:open, _) to understand - it can block the GenSever.
+      {:error, :timeout}
   end
 
   @impl true

--- a/lib/amqp/application/connection.ex
+++ b/lib/amqp/application/connection.ex
@@ -72,6 +72,8 @@ defmodule AMQP.Application.Connection do
   @doc false
   def get_state(name \\ :default) do
     GenServer.call(get_server_name(name), :get_state)
+  catch
+    :exit, {:timeout, _} -> %{}
   end
 
   @doc """
@@ -97,6 +99,8 @@ defmodule AMQP.Application.Connection do
     end
   catch
     :exit, {:timeout, _} ->
+      # This would happen when the connection is stuck when opening.
+      # See do_open/1 to understand - it can block the GenSever.
       {:error, :timeout}
   end
 


### PR DESCRIPTION
On top of @balena's work on #210 ...

- catch more GenServer.call timeout error
- add internal notes and explain how timeout error can be caused