### PR TITLE
Enhance `Application.get_channel` and `Application.get_connection`

### DIFF
--- a/lib/amqp/application/channel.ex
+++ b/lib/amqp/application/channel.ex
@@ -154,6 +154,10 @@ defmodule AMQP.Application.Channel do
     {:stop, reason, %{state | channel: nil, monitor_ref: nil}}
   end
 
+  def handle_info({ref, _res}, state) when is_reference(ref) do
+    {:noreply, state}
+  end
+
   @impl true
   def terminate(_reason, state) do
     close(state)

--- a/lib/amqp/application/connection.ex
+++ b/lib/amqp/application/connection.ex
@@ -93,9 +93,11 @@ defmodule AMQP.Application.Connection do
   """
   @spec get_connection(binary | atom) :: {:ok, Connection.t()} | {:error, any}
   def get_connection(name \\ :default) do
-    case GenServer.call(get_server_name(name), :get_connection) do
-      nil -> {:error, :not_connected}
-      conn -> {:ok, conn}
+    with false <- whereis(name) |> is_nil(),
+         conn <- GenServer.call(get_server_name(name), :get_connection) do
+      if conn |> is_nil(), do: {:error, :not_connected}, else: {:ok, conn}
+    else
+      true -> {:error, :connection_not_found}
     end
   catch
     :exit, {:timeout, _} ->

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AMQP.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/pma/amqp"
-  @version "3.1.0"
+  @version "3.1.1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AMQP.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/pma/amqp"
-  @version "3.1.1"
+  @version "3.1.0"
 
   def project do
     [

--- a/test/application/channel_test.exs
+++ b/test/application/channel_test.exs
@@ -32,4 +32,9 @@ defmodule AMQP.Application.ChnnelTest do
     refute chan1 == chan2
     GenServer.stop(pid)
   end
+
+  test "Unavailable channel does not crash" do
+    assert {:error, :channel_not_found} ==
+             AppChan.get_channel(:non_existing)
+  end
 end

--- a/test/application/connection_test.exs
+++ b/test/application/connection_test.exs
@@ -22,4 +22,9 @@ defmodule AMQP.Application.ConnectionTest do
     refute conn1 == conn2
     GenServer.stop(pid)
   end
+
+  test "Unavailable connection does not crash" do
+    assert {:error, :connection_not_found} ==
+             AppConn.get_connection(:non_existing)
+  end
 end


### PR DESCRIPTION
`Application.get_channel` and `Application.get_connection` no longer crash if the name of the process given is not alive.