### PR TITLE
Link AMQP.Application.Channel with AMQP.Channel instead of monitoring

### DIFF
--- a/test/application/channel_test.exs
+++ b/test/application/channel_test.exs
@@ -33,6 +33,50 @@ defmodule AMQP.Application.ChnnelTest do
     GenServer.stop(pid)
   end
 
+  test "AMQP connection alives when Application channel process exits" do
+    opts = [connection: :default, proc_name: :test_chan]
+    {:ok, pid} = AppChan.start_link(opts)
+    Process.unlink(pid)
+    {:ok, conn} = AppConn.get_connection()
+
+    Process.exit(pid, :normal)
+    :timer.sleep(50)
+    assert Process.alive?(conn.pid)
+  end
+
+  test "reconnects when the AMQP channel is killed" do
+    opts = [connection: :default, proc_name: :test_chan, retry_interval: 50]
+    {:ok, pid} = AppChan.start_link(opts)
+    {:ok, %AMQP.Channel{} = chan1} = AppChan.get_channel(:test_chan)
+    Process.exit(chan1.pid, :kill)
+    :timer.sleep(100)
+
+    {:ok, %AMQP.Channel{} = chan2} = AppChan.get_channel(:test_chan)
+    # Note the new channel also uses new connection.
+    # Since the chan1 was not closed safely, the connection would also die and restarted.
+    refute chan1.pid == chan2.pid
+    GenServer.stop(pid)
+  end
+
+  test "AMQP channel dies when Application Channel process is killed" do
+    opts = [connection: :default, proc_name: :test_chan]
+    {:ok, pid} = AppChan.start_link(opts)
+    Process.unlink(pid)
+    {:ok, conn1} = AppConn.get_connection()
+
+    {:ok, %AMQP.Channel{} = chan} = AppChan.get_channel(:test_chan)
+    Process.exit(pid, :kill)
+    :timer.sleep(50)
+    refute Process.alive?(chan.pid)
+
+    # Note that the connection is also reset when channel is killed.
+    # With a kill signal, the Application.Channel can not call the Channel.close.
+    # This causes the connection to be reset.
+    refute Process.alive?(conn1.pid)
+    {:ok, conn2} = AppConn.get_connection()
+    assert Process.alive?(conn2.pid)
+  end
+
   test "Unavailable channel does not crash" do
     assert {:error, :channel_not_found} ==
              AppChan.get_channel(:non_existing)


### PR DESCRIPTION
Made equivalent changes with #220 for Channel.

I think `:kill` signal is used in the extreme situation. In such situation, I think it is OK that other processes like Connection to be cascaded too. It safely reconnects as test shows.

For other exit reason, it handles the shutdown and wouldn't affect the connection.

@craigp what do you think?