### PR TITLE
Upgrade amqp_client dependency to fix frame_too_large error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule AMQP.Mixfile do
 
   defp deps do
     [
-      {:amqp_client, "~> 3.9"},
+      {:amqp_client, "~> 3.12"},
 
       # Docs dependencies.
       {:ex_doc, ">= 0.0.0", only: :docs},


### PR DESCRIPTION
After upgrading to Elixir 1.15.0 and OTP 26 our app could no longer establish a connection. Upgrading `amqp_client` to latest seems to fix the issue.

```
2023-06-20 09:21:47 2023-06-20 15:21:47.150 [info] <0.685.0> accepting AMQP connection <0.685.0> (172.25.0.1:51790 -> 172.25.0.6:5672)
2023-06-20 09:21:50 2023-06-20 15:21:50.193 [error] <0.685.0> closing AMQP connection <0.685.0> (172.25.0.1:51790 -> 172.25.0.6:5672):
2023-06-20 09:21:50 {handshake_error,starting,26721,{amqp_error,frame_error,"type 99, all octets = <<>>: {frame_too_large,1852269919,4088}",none}}
```