### PR TITLE
docs: remove fail_if_no_peer_cert from example

### DIFF
--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -112,8 +112,7 @@ defmodule AMQP.Connection do
           keyfile: '/path/to/client/key.pem',
           # only necessary with intermediate CAs
           # depth: 2,
-          verify: :verify_peer,
-          fail_if_no_peer_cert: true
+          verify: :verify_peer
         ]
       )
 


### PR DESCRIPTION
The code example for an SSL connection included the `fail_if_no_peer_cert` option. However, that is an option for the server side. If used in a client, this will result in the error `{:error, {:option, :server_only, :fail_if_no_peer_cert}}` in OTP 26 (see https://www.erlang.org/blog/otp-26-highlights/#ssl-improved-checking-of-options).