### PR TITLE
Test with Elixir 1.17

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.0.1
-          elixir-version: 1.16.x
+          otp-version: 26.x
+          elixir-version: 1.17.x
           experimental-otp: true
 
       - name: Install dependencies
@@ -32,6 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # rabbit_common currently does not compile against OTP v27.
+          # This needs to be fixed upstream to achieve compatibility.
+          #- otp: 27.x
+          #  elixir: 1.17.x
+          - otp: 26.x
+            elixir: 1.17.x
           - otp: 26.x
             elixir: 1.16.x
           - otp: 26.x


### PR DESCRIPTION
This module appears to work fine with Elixir v1.17.

Not so much with OTP v27, there’s a compiler error in `rabbit_common`:

```
===> Compiling rabbit_common
===> Compiling src/rabbit_types.erl failed
rabbit_types.erl:14:20: syntax error before: '/'
rabbit_types.erl:38:16: syntax error before: '::'
```