### PR TITLE
Fix typos again

### DIFF
--- a/lib/amqp/basic.ex
+++ b/lib/amqp/basic.ex
@@ -230,7 +230,7 @@ defmodule AMQP.Basic do
   ## Options
 
     * `:no_ack` - If set, the broker is told that the received will not send an
-      acknoledgement of the message. Once the broker believes it has delivered
+      acknowledgement of the message. Once the broker believes it has delivered
       the message, then it's free to assume that the consuming application has
       taken responsibility for it. In general, a lot of applications will not
       want these semantics, rather, they will want to explicitly acknowledge the

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -56,7 +56,7 @@ defmodule AMQP.Connection do
 
     * `:frame_max` - The frame_max handshake parameter (defaults `0`)
 
-    * `:heartbeat` - The hearbeat interval in seconds (defaults `10`)
+    * `:heartbeat` - The heartbeat interval in seconds (defaults `10`)
 
     * `:connection_timeout` - The connection timeout in milliseconds (efaults
       `50000`)

--- a/test/application/channel_test.exs
+++ b/test/application/channel_test.exs
@@ -1,4 +1,4 @@
-defmodule AMQP.Application.ChnnelTest do
+defmodule AMQP.Application.ChannelTest do
   use ExUnit.Case
   alias AMQP.Application.Connection, as: AppConn
   alias AMQP.Application.Channel, as: AppChan


### PR DESCRIPTION
Found via `codespell -H` and `typos --hidden --format brief`