### PR TITLE
Allow advanced channel parameters - specifically channel numbers - when opening a channel

### DIFF
--- a/test/channel_test.exs
+++ b/test/channel_test.exs
@@ -14,4 +14,33 @@ defmodule ChannelTest do
     assert {:ok, chan} = Channel.open(meta[:conn])
     assert :ok = Channel.close(chan)
   end
+
+  test "open channel with channel number only", meta do
+    assert {:ok, chan} = Channel.open(meta[:conn], channel_number: 90)
+    assert {AMQP.SelectiveConsumer, _pid} = chan.custom_consumer
+    assert :ok = Channel.close(chan)
+  end
+
+  test "open channel with custom_consumer only", meta do
+    assert {:ok, chan} = Channel.open(meta[:conn], custom_consumer: {AMQP.DirectConsumer, self()})
+    assert {AMQP.DirectConsumer, _pid} = chan.custom_consumer
+    assert :ok = Channel.close(chan)
+  end
+
+  test "open channel with channel number and custom_consumer only", meta do
+    assert {:ok, chan} =
+             Channel.open(meta[:conn],
+               channel_number: 12,
+               custom_consumer: {AMQP.DirectConsumer, self()}
+             )
+
+    assert {AMQP.DirectConsumer, _pid} = chan.custom_consumer
+    assert :ok = Channel.close(chan)
+  end
+
+  test "open channel with old custom consumer only argument", meta do
+    assert {:ok, chan} = Channel.open(meta[:conn], {AMQP.DirectConsumer, self()})
+    assert {AMQP.DirectConsumer, _pid} = chan.custom_consumer
+    assert :ok = Channel.close(chan)
+  end
 end


### PR DESCRIPTION
This PR is an effort to allow us to define the channel number when opening a channel. 

We need this because we have a large number of channels per connection that are constantly being created and destroyed on a schedule. Unfortunately, the channel number continuously increments and over time hits the limit of 65535 and the next channel to attempt to open crashes the channel pool, which in turn crashes the broadway consumers. Since we're using a supervision tree, everything comes back up just fine, but we'd prefer not to crash in the first place. 

Exposing this option should allow us to use our channel pool and some atomic datastore to track the current channels and re-use channel numbers that have been destroyed. 