### PR TITLE
Better formatting to `iex` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ defmodule Consumer do
 end
 ```
 
-```iex
+```elixir
 iex> Consumer.start_link
 {:ok, #PID<0.261.0>}
 iex> {:ok, conn} = AMQP.Connection.open


### PR DESCRIPTION
Now:
<img width="732" height="377" alt="image" src="https://github.com/user-attachments/assets/b4c52b1d-8280-45ec-a083-df8636f10356" />

After this PR:
<img width="1028" height="361" alt="image" src="https://github.com/user-attachments/assets/9f6bfa27-97c8-412e-86e3-aa02462d64f2" />
