### PR TITLE
Fix unused require Logger warning

### DIFF
--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -4,7 +4,6 @@ defmodule AMQP.Application do
   """
 
   use Application
-  require Logger
 
   @impl true
   def start(_type, _args) do


### PR DESCRIPTION
```
==> amqp
Compiling 16 files (.ex)          
    warning: unused require Logger
    │                             
  7 │   require Logger       
    │   ~
    │
    └─ lib/amqp/application.ex:7:3
```

Last use of Logger in `AMQP.Application` was removed in bf78f6c.