### PR TITLE
Fix transient nonexcl queues issue with RabbitMQ 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 /log
 /doc
 /cover
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -252,6 +252,45 @@ As long as the client works with the old RabbitMQ version, our library will also
 
 Here is [the comment](https://github.com/rabbitmq/rabbitmq-server/issues/12510#issuecomment-2442175567) from the RabbitMQ team.
 
+#### Why does RabbitMQ 4 reject `Queue.declare(chan)` with `transient_nonexcl_queues`?
+
+RabbitMQ 4 can deny the deprecated `transient_nonexcl_queues` feature by
+default. This feature covers queues that are both non-durable and
+non-exclusive.
+
+`Queue.declare(chan)` uses AMQP's historical defaults:
+
+```elixir
+Queue.declare(chan, "", durable: false, exclusive: false, auto_delete: false)
+```
+
+That means the queue is transient (`durable: false`) and non-exclusive
+(`exclusive: false`), so RabbitMQ 4 may close the connection with an error like:
+
+```text
+Feature `transient_nonexcl_queues` is deprecated.
+```
+
+To avoid the deprecated feature, declare the queue as either durable:
+
+```elixir
+Queue.declare(chan, "jobs", durable: true)
+```
+
+or exclusive when you need a private temporary queue:
+
+```elixir
+Queue.declare(chan, "", exclusive: true)
+```
+
+If you need to keep using non-durable, non-exclusive queues while migrating to a
+newer RabbitMQ version, permit the deprecated feature in the broker
+configuration:
+
+```conf
+deprecated_features.permit.transient_nonexcl_queues = true
+```
+
 #### Does the library support AMQP 1.0?
 
 No, it doesn't. This library supports only AMQP 0.9.1, and we have no plans to support 1.0 at this time.

--- a/config/rabbitmq4.conf
+++ b/config/rabbitmq4.conf
@@ -1,0 +1,1 @@
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/docker-compose.rabbitmq3.yml
+++ b/docker-compose.rabbitmq3.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   rabbitmq:
     image: "rabbitmq:3-alpine"

--- a/docker-compose.rabbitmq4.yml
+++ b/docker-compose.rabbitmq4.yml
@@ -1,7 +1,7 @@
-version: '3'
-
 services:
   rabbitmq:
     image: "rabbitmq:4-alpine"
     ports:
       - "5672:5672"
+    volumes:
+      - "./config/rabbitmq4.conf:/etc/rabbitmq/conf.d/20-deprecated-features.conf:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   rabbitmq:
     image: "rabbitmq:alpine"


### PR DESCRIPTION
## Summary

This updates the RabbitMQ 4 development/test setup and documentation for RabbitMQ’s deprecated `transient_nonexcl_queues` feature.

RabbitMQ 4 can deny non-durable, non-exclusive queues by default. Since `Queue.declare(chan)` uses AMQP’s historical defaults of `durable: false` and `exclusive: false`, users can hit a broker-initiated connection close when running against RabbitMQ 4.

## Changes

- Add RabbitMQ 4 config to permit `transient_nonexcl_queues` for the local test container.
- Mount that config from `docker-compose.rabbitmq4.yml`.
- Remove the obsolete top-level Compose `version` field.
- Document why `Queue.declare(chan)` can trigger this RabbitMQ 4 error.
- Document alternatives:
  - use `durable: true` for durable named queues
  - use `exclusive: true` for private temporary queues
  - temporarily permit the deprecated feature in RabbitMQ config while migrating

## Verification

- `docker compose -f docker-compose.rabbitmq4.yml config`
- `docker compose -f docker-compose.rabbitmq4.yml up -d`
- `mix test`

Result: `67 passed`